### PR TITLE
refactor: convert version-env to library module

### DIFF
--- a/lib/run-with-version-env.js
+++ b/lib/run-with-version-env.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { spawn, execSync } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { resolve, join, dirname } from 'node:path'
@@ -47,7 +45,7 @@ async function readPackageVersion(app) {
   const appDirMap = {
     backend: 'apps/backend/package.json',
     front: 'apps/front/package.json',
-    admin: 'apps/admin-front/package.json',
+    admin: 'apps/admin-front/package.json'
   }
   const pkgPath = appDirMap[app]
   if (!pkgPath) return '0.0.0'
@@ -101,7 +99,7 @@ function buildEnv(app, baseEnv, extraEnv) {
         ['BUILD_GIT_SHA', gitSha],
         ['BUILD_TIME', now],
         ['BUILD_TIMESTAMP', now],
-        ['BUILD_NUMBER', buildNumber],
+        ['BUILD_NUMBER', buildNumber]
       ])
       break
     }
@@ -112,7 +110,7 @@ function buildEnv(app, baseEnv, extraEnv) {
         ['NEXT_PUBLIC_GIT_SHA', gitSha],
         ['NEXT_PUBLIC_GIT_SHORT_SHA', gitShort],
         ['NEXT_PUBLIC_BUILD_TIME', now],
-        ['NEXT_PUBLIC_BUILD_NUMBER', buildNumber],
+        ['NEXT_PUBLIC_BUILD_NUMBER', buildNumber]
       ])
       break
     }
@@ -123,7 +121,7 @@ function buildEnv(app, baseEnv, extraEnv) {
         ['VITE_GIT_SHA', gitSha],
         ['VITE_GIT_SHORT_SHA', gitShort],
         ['VITE_BUILD_TIME', now],
-        ['VITE_BUILD_NUMBER', buildNumber],
+        ['VITE_BUILD_NUMBER', buildNumber]
       ])
       break
     }
@@ -150,7 +148,7 @@ export async function runWithVersionEnv(argv = []) {
   const child = spawn(command[0], command.slice(1), {
     stdio: 'inherit',
     env,
-    shell: false,
+    shell: false
   })
 
   child.on('exit', code => {
@@ -162,12 +160,3 @@ export async function runWithVersionEnv(argv = []) {
     process.exit(1)
   })
 }
-
-async function main() {
-  await runWithVersionEnv(process.argv.slice(2))
-}
-
-main().catch(error => {
-  console.error('[with-version-env] 执行失败:', error)
-  process.exit(1)
-})


### PR DESCRIPTION
## 变更说明

- 移除 shebang (`#!/usr/bin/env node`) 和独立的 main 函数
- 将文件从可执行脚本转换为纯库模块
- 删除尾部逗号以符合代码规范
- 保留核心 `runWithVersionEnv` 导出函数供外部调用

## 测试

- [ ] 本地测试通过
- [ ] 确认模块可正常导入和使用