### PR TITLE
refactor: use strip-json-comments library for JSONC parsing

### DIFF
--- a/lib/env-policy.js
+++ b/lib/env-policy.js
@@ -1,14 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import stripJsonComments from 'strip-json-comments'
 
 const DEFAULT_POLICY_PATH = 'env-policy.jsonc'
 
 let cachedPolicy = null
 let cachedPolicyDir = null
-
-function sanitizeJsonc(raw) {
-  return raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
-}
 
 function assertStringArray(value, fieldPath) {
   if (!Array.isArray(value)) {
@@ -39,7 +36,7 @@ export function loadEnvPolicy(configDir) {
   let parsed
   try {
     const raw = readFileSync(policyPath, 'utf8')
-    parsed = JSON.parse(sanitizeJsonc(raw) || '{}')
+    parsed = JSON.parse(stripJsonComments(raw) || '{}')
   } catch (error) {
     throw new Error(`无法解析 ${DEFAULT_POLICY_PATH}: ${error.message}`)
   }

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import stripJsonComments from 'strip-json-comments'
 
 function resolveProjectRoot() {
   return process.env.DX_PROJECT_ROOT || process.cwd()
@@ -112,7 +113,7 @@ export class EnvManager {
 
     try {
       const raw = readFileSync(configPath, 'utf8')
-      const sanitized = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+      const sanitized = stripJsonComments(raw)
       this.requiredEnvConfig = JSON.parse(sanitized || '{}') || { _common: [] }
     } catch (error) {
       throw new Error(`无法解析 required-env.jsonc: ${error.message}`)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "dependencies": {
+    "strip-json-comments": "^5.0.3",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      strip-json-comments:
+        specifier: ^5.0.3
+        version: 5.0.3
       yaml:
         specifier: ^2.8.1
         version: 2.8.2
@@ -1014,6 +1017,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2373,6 +2380,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   supports-color@7.2.0:
     dependencies:


### PR DESCRIPTION
## 变更说明

- 移除自定义 sanitizeJsonc 函数，使用 strip-json-comments 标准库替代
- 应用于 env-policy.js 和 env.js 的 JSONC 解析
- 提高代码可维护性和可靠性

## 测试

- [ ] 本地测试通过
- [ ] JSONC 注释解析功能正常