### PR TITLE
fix: 修复 Telegram Webhook 部署 URL 解析与状态判定

### DIFF
--- a/lib/cli/commands/deploy.js
+++ b/lib/cli/commands/deploy.js
@@ -40,7 +40,7 @@ export function parseTelegramWebhookFlags(argv = []) {
 
   const dryRun = args.includes('--webhook-dry-run') ? true : undefined
 
-  // 默认值由下游根据 environment 决定，这里只负责覆盖
+  // 默认值由下游决定（当前为默认严格），这里仅处理显式覆盖
   const strict = args.includes('--strict-webhook')
     ? true
     : args.includes('--no-strict-webhook')

--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -194,7 +194,7 @@ script 子命令:
   Telegram Webhook（仅 target=telegram-bot 生效）:
     --webhook-path <path>       对外 webhook 路径（默认 /api/webhook）
     --webhook-dry-run           只打印将设置的 URL，不调用 Telegram API
-    --strict-webhook            强制严格校验（Webhook 不生效则 deploy 失败）
+    --strict-webhook            显式开启严格校验（默认已严格）
     --no-strict-webhook         关闭严格校验（仅告警）
 
   常见示例:
@@ -203,7 +203,7 @@ script 子命令:
   dx deploy telegram-bot --staging    # 部署 Telegram Bot + 自动配置 Webhook
   dx deploy telegram-bot --staging --webhook-path /webhook    # 使用短路径（rewrite 到 /api/webhook）
   dx deploy telegram-bot --prod --webhook-dry-run             # 仅打印，不实际调用 Telegram
-  dx deploy telegram-bot --prod --no-strict-webhook           # 生产环境也仅告警（不推荐）
+  dx deploy telegram-bot --dev --no-strict-webhook            # 开发环境显式降级为仅告警
   dx deploy all --staging             # 串行部署 front + admin
 `)
       return

--- a/lib/telegram-webhook.js
+++ b/lib/telegram-webhook.js
@@ -17,11 +17,35 @@ function normalizeDeployUrl(raw) {
 }
 
 export function parseDeployUrlFromDeployOutput(output) {
-  const s = String(output || '')
-  const matches = [...s.matchAll(/(https?:\/\/)?([a-z0-9-]+\.vercel\.app)\b/gi)]
-  if (matches.length === 0) return null
-  const last = matches[matches.length - 1]
-  return `https://${last[2]}`
+  const lines = String(output || '')
+    .split(/\r?\n/)
+    .map(line => String(line || '').trim())
+    .filter(Boolean)
+
+  const pickUrl = line => {
+    const m = line.match(/(https?:\/\/)?([a-z0-9-]+\.vercel\.app)\b/i)
+    return m ? `https://${m[2]}` : null
+  }
+
+  for (const line of lines) {
+    if (!/^production\s*:/i.test(line)) continue
+    const url = pickUrl(line)
+    if (url) return url
+  }
+
+  for (const line of lines) {
+    if (!/^preview\s*:/i.test(line)) continue
+    const url = pickUrl(line)
+    if (url) return url
+  }
+
+  for (const line of lines) {
+    if (/to deploy to production/i.test(line)) continue
+    const url = pickUrl(line)
+    if (url) return url
+  }
+
+  return null
 }
 
 export function parseDeployUrlFromVercelListOutput(output, projectNameHint) {
@@ -72,7 +96,7 @@ export async function handleTelegramBotDeploy(environment, projectId, orgId, tok
     strict: strictOverride,
   } = options || {}
 
-  const strictDefault = environment !== 'development'
+  const strictDefault = true
 
   const strictEnv = process.env.DX_TELEGRAM_WEBHOOK_STRICT != null
     ? !['0', 'false', 'no'].includes(String(process.env.DX_TELEGRAM_WEBHOOK_STRICT).toLowerCase())
@@ -103,12 +127,25 @@ export async function handleTelegramBotDeploy(environment, projectId, orgId, tok
       logger.error(`  - ${v}`)
     })
 
+    const message = 'Telegram Webhook 配置失败：缺少必需环境变量'
     if (strict) {
-      throw new Error('Telegram Webhook 配置失败：缺少必需环境变量')
+      return {
+        status: 'failed',
+        reason: 'missing_env_vars',
+        strict,
+        message,
+        missingVars,
+      }
     }
 
     logger.warn('跳过 Webhook 配置，请手动设置')
-    return
+    return {
+      status: 'warning',
+      reason: 'missing_env_vars',
+      strict,
+      message,
+      missingVars,
+    }
   }
 
   try {
@@ -122,12 +159,22 @@ export async function handleTelegramBotDeploy(environment, projectId, orgId, tok
       projectNameHint,
     })
     if (!deploymentUrl) {
+      const message = '无法获取 Vercel 部署 URL'
       if (strict) {
-        throw new Error('无法获取 Vercel 部署 URL')
+        return {
+          status: 'failed',
+          reason: 'missing_deploy_url',
+          strict,
+          message,
+        }
       }
-
       logger.error('无法获取 Vercel 部署 URL，跳过 Webhook 配置')
-      return
+      return {
+        status: 'warning',
+        reason: 'missing_deploy_url',
+        strict,
+        message,
+      }
     }
 
     const webhookUrl = `${deploymentUrl}${webhookPath}`
@@ -135,7 +182,13 @@ export async function handleTelegramBotDeploy(environment, projectId, orgId, tok
 
     if (dryRun) {
       logger.warn('DX_TELEGRAM_WEBHOOK_DRY_RUN=1，已跳过 setWebhook/getWebhookInfo 调用')
-      return
+      return {
+        status: 'warning',
+        reason: 'dry_run',
+        strict,
+        message: 'DX_TELEGRAM_WEBHOOK_DRY_RUN=1',
+        webhookUrl,
+      }
     }
 
     // 3. 调用 Telegram API 设置 Webhook
@@ -163,15 +216,38 @@ export async function handleTelegramBotDeploy(environment, projectId, orgId, tok
       logger.info(`Webhook URL: ${webhookUrl}`)
 
       // 4. 验证 Webhook 状态
-      await verifyWebhook(botToken, webhookUrl, { strict })
+      const verifyResult = await verifyWebhook(botToken, webhookUrl, { strict })
+      if (verifyResult.status === 'success') {
+        return {
+          status: 'success',
+          reason: 'verified',
+          strict,
+          webhookUrl,
+        }
+      }
+
+      return {
+        status: strict ? 'failed' : 'warning',
+        reason: 'verify_failed',
+        strict,
+        message: verifyResult.message,
+        webhookUrl,
+      }
     }
     else {
       const desc = result.description || '未知错误'
+      const message = `Telegram Webhook 设置失败: ${desc}`
       if (strict) {
-        throw new Error(`Telegram Webhook 设置失败: ${desc}`)
+        return {
+          status: 'failed',
+          reason: 'set_webhook_failed',
+          strict,
+          message,
+          webhookUrl,
+        }
       }
 
-      logger.error(`Telegram Webhook 设置失败: ${desc}`)
+      logger.error(message)
       logger.info('请手动执行以下命令（不要把明文 token/secret 写进日志）:')
       const manualPayload = JSON.stringify({
         url: webhookUrl,
@@ -181,15 +257,28 @@ export async function handleTelegramBotDeploy(environment, projectId, orgId, tok
       logger.info(
         `curl -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" -H "Content-Type: application/json" -d '${manualPayload}' --silent`,
       )
+      return {
+        status: 'warning',
+        reason: 'set_webhook_failed',
+        strict,
+        message,
+        webhookUrl,
+      }
     }
   }
   catch (error) {
     const message = error?.message || String(error)
     logger.error(`Webhook 配置失败: ${message}`)
 
-    if (strict) throw error
-
-    logger.warn('请手动设置 Webhook（参考 apps/telegram-bot/README.md）')
+    if (!strict) {
+      logger.warn('请手动设置 Webhook（参考 apps/telegram-bot/README.md）')
+    }
+    return {
+      status: strict ? 'failed' : 'warning',
+      reason: 'runtime_error',
+      strict,
+      message,
+    }
   }
 }
 
@@ -315,19 +404,28 @@ async function verifyWebhook(botToken, expectedWebhookUrl, options = {}) {
 
       if (expectedWebhookUrl && info.url !== expectedWebhookUrl) {
         const message = `Webhook 未生效：期望 ${expectedWebhookUrl}，实际 ${info.url || '(empty)'}`
-        if (strict) throw new Error(message)
+        if (strict) {
+          return { status: 'failed', message }
+        }
         logger.warn(message)
+        return { status: 'warning', message }
       }
+      return { status: 'success' }
     }
     else {
       const desc = result?.description || '未知错误'
       const message = `getWebhookInfo 失败: ${desc}`
-      if (strict) throw new Error(message)
+      if (strict) {
+        return { status: 'failed', message }
+      }
       logger.warn(message)
+      return { status: 'warning', message }
     }
   }
   catch (error) {
-    if (strict) throw error
+    const message = error?.message || String(error)
+    if (strict) return { status: 'failed', message }
     logger.warn('无法验证 Webhook 状态')
+    return { status: 'warning', message: '无法验证 Webhook 状态' }
   }
 }

--- a/lib/vercel-deploy.js
+++ b/lib/vercel-deploy.js
@@ -260,6 +260,7 @@ export async function deployToVercel(target, options = {}) {
   const {
     environment = 'staging',
     telegramWebhook = null,
+    telegramWebhookHandler = null,
     strictContext = true,
     run = runVercel
   } = options
@@ -482,13 +483,26 @@ export async function deployToVercel(target, options = {}) {
 
       // Telegram Bot 部署成功后自动设置 Webhook（并做严格校验）
       if (t === 'telegram-bot') {
-        const { handleTelegramBotDeploy } = await import('./telegram-webhook.js')
-        await handleTelegramBotDeploy(environment, projectId, orgId, token, {
+        const resolvedWebhookHandler = telegramWebhookHandler
+          || (await import('./telegram-webhook.js')).handleTelegramBotDeploy
+        const webhookResult = await resolvedWebhookHandler(environment, projectId, orgId, token, {
           deployOutput,
           projectNameHint: 'telegram-bot',
           ...(telegramWebhook || {})
         })
-        logger.success(`${t} 部署成功（Webhook 已校验）`)
+
+        if (webhookResult?.status === 'success') {
+          logger.success(`${t} 部署成功（Webhook 已校验）`)
+        } else if (webhookResult?.status === 'failed') {
+          const reason = webhookResult?.message || webhookResult?.reason || '未知原因'
+          logger.error(`${t} 部署成功，但 Webhook 配置失败: ${reason}`)
+          process.exitCode = 1
+          return
+        } else {
+          const reason = webhookResult?.message || webhookResult?.reason || '未严格校验'
+          logger.warn(`${t} 部署成功，但 Webhook 未完成校验: ${reason}`)
+          logger.success(`${t} 部署成功`)
+        }
       } else {
         logger.success(`${t} 部署成功`)
       }


### PR DESCRIPTION
变更说明：
- 调整部署输出 URL 解析优先级，优先使用 Production 行，避免误选 Preview 域名
- 将 Telegram Webhook 配置与校验结果统一为结构化状态（success/warning/failed）
- 在 Vercel 部署流程中按 Webhook 返回状态控制日志与退出码
- 更新 deploy CLI 文案以匹配“默认严格校验”行为
- 增补并更新相关单测，覆盖 warning/failed 分支与 URL 选择回归

Refs: #10