### PR TITLE
fix: 修复后端制品部署的校验与依赖处理

### DIFF
--- a/lib/backend-artifact-deploy/artifact-builder.js
+++ b/lib/backend-artifact-deploy/artifact-builder.js
@@ -8,6 +8,11 @@ import { basenameOrThrow, resolveWithinBase } from './path-utils.js'
 import { createRuntimePackage } from './runtime-package.js'
 
 const execFileAsync = promisify(execFile)
+const tarEnv = {
+  ...process.env,
+  COPYFILE_DISABLE: '1',
+  COPY_EXTENDED_ATTRIBUTES_DISABLE: '1',
+}
 
 function assertSafeNamePart(value, label) {
   const text = String(value || '').trim()
@@ -125,15 +130,21 @@ async function defaultCreateInnerArchive({ stageDir, innerArchivePath }) {
   await mkdir(dirname(innerArchivePath), { recursive: true })
   await execFileAsync('tar', ['-czf', innerArchivePath, '.'], {
     cwd: stageDir,
+    env: tarEnv,
   })
 }
 
 async function defaultWriteChecksum({ archivePath, checksumPath }) {
+  const archiveName = basename(archivePath)
   try {
-    const { stdout } = await execFileAsync('sha256sum', [archivePath])
+    const { stdout } = await execFileAsync('sha256sum', [archiveName], {
+      cwd: dirname(archivePath),
+    })
     await writeFile(checksumPath, stdout)
   } catch {
-    const { stdout } = await execFileAsync('shasum', ['-a', '256', archivePath])
+    const { stdout } = await execFileAsync('shasum', ['-a', '256', archiveName], {
+      cwd: dirname(archivePath),
+    })
     await writeFile(checksumPath, stdout)
   }
 }
@@ -142,7 +153,10 @@ async function defaultCreateBundle({ outputDir, bundlePath, innerArchivePath, ch
   await execFileAsync(
     'tar',
     ['-czf', bundlePath, basename(innerArchivePath), basename(checksumPath)],
-    { cwd: outputDir },
+    {
+      cwd: outputDir,
+      env: tarEnv,
+    },
   )
 }
 

--- a/lib/backend-artifact-deploy/remote-script.js
+++ b/lib/backend-artifact-deploy/remote-script.js
@@ -157,15 +157,16 @@ find_single_bundle_file() {
 
 sha256_check() {
   local checksum_file="$1"
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum -c "$checksum_file"
-    return
-  fi
-  local checksum expected file
+  local checksum file actual
   checksum="$(awk '{print $1}' "$checksum_file")"
   file="$(awk '{print $2}' "$checksum_file")"
-  expected="$(shasum -a 256 "$file" | awk '{print $1}')"
-  [[ "$checksum" == "$expected" ]]
+  file="$(basename "$file")"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  else
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  fi
+  [[ "$checksum" == "$actual" ]]
 }
 
 run_with_env() {
@@ -213,7 +214,7 @@ CURRENT_PHASE="extract"
 echo "DX_REMOTE_PHASE=extract"
 validate_archive_entries "$ARCHIVE"
 BUNDLE_TEMP_DIR="$(mktemp -d "$APP_ROOT/.bundle-extract.XXXXXX")"
-tar -xzf "$ARCHIVE" -C "$BUNDLE_TEMP_DIR" --strip-components=1
+tar -xzf "$ARCHIVE" -C "$BUNDLE_TEMP_DIR"
 
 INNER_ARCHIVE="$(find_single_bundle_file "$BUNDLE_TEMP_DIR" 'backend-v*.tgz')"
 INNER_ARCHIVE_SHA256_FILE="$(find_single_bundle_file "$BUNDLE_TEMP_DIR" 'backend-v*.tgz.sha256')"

--- a/lib/backend-artifact-deploy/remote-transport.js
+++ b/lib/backend-artifact-deploy/remote-transport.js
@@ -114,5 +114,9 @@ export async function deployBackendArtifactRemotely(config, bundle, deps = {}) {
   const phaseModel = createRemotePhaseModel(payload)
   const script = buildRemoteDeployScript(phaseModel)
   const commandResult = await runRemoteScript(config.remote, script)
-  return parseRemoteResult(commandResult)
+  const result = parseRemoteResult(commandResult)
+  if (!result.ok) {
+    throw new Error(`远端部署失败(${result.phase}): ${result.message}`)
+  }
+  return result
 }

--- a/lib/backend-artifact-deploy/runtime-package.js
+++ b/lib/backend-artifact-deploy/runtime-package.js
@@ -1,5 +1,5 @@
 const UNSUPPORTED_LOCAL_DEP_PATTERN = /^(workspace:|file:|link:)/
-const REQUIRED_DEPENDENCIES_FROM_DEV = ['prisma']
+const REQUIRED_DEPENDENCIES = ['prisma', 'tslib', 'dotenv-cli', '@prisma/adapter-pg']
 
 function assertSupportedDependencies(dependencies = {}) {
   for (const [name, version] of Object.entries(dependencies)) {
@@ -13,10 +13,15 @@ function assertSupportedDependencies(dependencies = {}) {
 export function createRuntimePackage({ appPackage, rootPackage }) {
   const runtimeDependencies = { ...(appPackage?.dependencies || {}) }
   const appDevDependencies = appPackage?.devDependencies || {}
+  const rootDependencies = rootPackage?.dependencies || {}
+  const rootDevDependencies = rootPackage?.devDependencies || {}
 
-  for (const dependencyName of REQUIRED_DEPENDENCIES_FROM_DEV) {
-    if (!runtimeDependencies[dependencyName] && appDevDependencies[dependencyName]) {
-      runtimeDependencies[dependencyName] = appDevDependencies[dependencyName]
+  for (const dependencyName of REQUIRED_DEPENDENCIES) {
+    if (!runtimeDependencies[dependencyName]) {
+      runtimeDependencies[dependencyName] =
+        appDevDependencies[dependencyName]
+        || rootDependencies[dependencyName]
+        || rootDevDependencies[dependencyName]
     }
   }
 

--- a/test/backend-artifact-builder.test.js
+++ b/test/backend-artifact-builder.test.js
@@ -208,4 +208,32 @@ describe('backend artifact builder', () => {
       rmSync(tempDir, { recursive: true, force: true })
     }
   })
+
+  test('writes checksum using the archive basename instead of an absolute path', async () => {
+    const deps = {
+      nowTag: jest.fn(() => '20260312-010203'),
+      readVersion: jest.fn(async () => '1.2.3'),
+      runBuild: jest.fn(async () => {}),
+      prepareOutputDir: jest.fn(async () => {}),
+      stageFiles: jest.fn(async () => {}),
+      assertNoEnvFiles: jest.fn(async () => {}),
+      createInnerArchive: jest.fn(async () => {}),
+      writeChecksum: jest.fn(async () => {}),
+      createBundle: jest.fn(async () => {}),
+    }
+
+    await buildBackendArtifact(
+      {
+        build: { command: 'build', versionFile: '/repo/apps/backend/package.json' },
+        runtime: { appPackage: '/repo/apps/backend/package.json', rootPackage: '/repo/package.json', lockfile: '/repo/pnpm-lock.yaml' },
+        artifact: { outputDir: '/repo/release/backend', bundleName: 'backend-bundle' },
+      },
+      deps,
+    )
+
+    expect(deps.writeChecksum).toHaveBeenCalledWith({
+      archivePath: '/repo/release/backend/backend-v1.2.3-20260312-010203.tgz',
+      checksumPath: '/repo/release/backend/backend-v1.2.3-20260312-010203.tgz.sha256',
+    })
+  })
 })

--- a/test/backend-artifact-remote-script.test.js
+++ b/test/backend-artifact-remote-script.test.js
@@ -60,4 +60,12 @@ describe('remote deploy script', () => {
     expect(script).toContain('包含可疑链接目标')
     expect(script).toContain('目标路径越界')
   })
+
+  test('extracts outer bundle without stripping the top-level files and normalizes checksum lookup', () => {
+    const script = buildRemoteDeployScript(createRemotePhaseModel(createPayload()))
+
+    expect(script).toContain('tar -xzf "$ARCHIVE" -C "$BUNDLE_TEMP_DIR"')
+    expect(script).not.toContain('tar -xzf "$ARCHIVE" -C "$BUNDLE_TEMP_DIR" --strip-components=1')
+    expect(script).toContain('file="$(basename "$file")"')
+  })
 })

--- a/test/backend-artifact-remote-transport.test.js
+++ b/test/backend-artifact-remote-transport.test.js
@@ -63,7 +63,7 @@ describe('deployBackendArtifactRemotely', () => {
     expect(result.ok).toBe(true)
   })
 
-  test('surfaces missing shared env file, lock contention, and checksum mismatch', async () => {
+  test('throws when the remote deploy script reports a failure result', async () => {
     const deps = {
       ensureRemoteBaseDirs: jest.fn(async () => {}),
       uploadBundle: jest.fn(async () => {}),
@@ -74,14 +74,13 @@ describe('deployBackendArtifactRemotely', () => {
       })),
     }
 
-    const result = await deployBackendArtifactRemotely(
-      createConfig(),
-      { versionName: 'backend-v1.2.3-20260312-010203', bundlePath: '/tmp/backend-bundle.tgz' },
-      deps,
-    )
-
-    expect(result.ok).toBe(false)
-    expect(result.phase).toBe('env')
+    await expect(
+      deployBackendArtifactRemotely(
+        createConfig(),
+        { versionName: 'backend-v1.2.3-20260312-010203', bundlePath: '/tmp/backend-bundle.tgz' },
+        deps,
+      ),
+    ).rejects.toThrow('远端部署失败(env): missing shared env')
   })
 
   test('surfaces upload failure and missing remote tool failure', async () => {
@@ -111,12 +110,12 @@ describe('deployBackendArtifactRemotely', () => {
       })),
     }
 
-    const result = await deployBackendArtifactRemotely(
-      createConfig(),
-      { versionName: 'backend-v1.2.3-20260312-010203', bundlePath: '/tmp/backend-bundle.tgz' },
-      toolDeps,
-    )
-
-    expect(result.message).toContain('missing pnpm')
+    await expect(
+      deployBackendArtifactRemotely(
+        createConfig(),
+        { versionName: 'backend-v1.2.3-20260312-010203', bundlePath: '/tmp/backend-bundle.tgz' },
+        toolDeps,
+      ),
+    ).rejects.toThrow('远端部署失败(install): missing pnpm')
   })
 })

--- a/test/backend-artifact-runtime-package.test.js
+++ b/test/backend-artifact-runtime-package.test.js
@@ -61,6 +61,38 @@ describe('createRuntimePackage', () => {
     })
   })
 
+  test('promotes required runtime helpers from devDependencies or root package', () => {
+    const runtimePackage = createRuntimePackage({
+      appPackage: {
+        name: '@repo/backend',
+        version: '1.2.3',
+        dependencies: {
+          express: '^4.0.0',
+        },
+        devDependencies: {
+          prisma: '^6.0.0',
+          '@prisma/adapter-pg': '^6.0.0',
+        },
+      },
+      rootPackage: {
+        dependencies: {
+          tslib: '^2.8.1',
+        },
+        devDependencies: {
+          'dotenv-cli': '^8.0.0',
+        },
+      },
+    })
+
+    expect(runtimePackage.dependencies).toEqual({
+      express: '^4.0.0',
+      prisma: '^6.0.0',
+      tslib: '^2.8.1',
+      'dotenv-cli': '^8.0.0',
+      '@prisma/adapter-pg': '^6.0.0',
+    })
+  })
+
   test('fails on workspace dependencies that cannot be installed remotely', () => {
     expect(() =>
       createRuntimePackage({


### PR DESCRIPTION
## 变更说明

- 为 artifact builder 的 tar 打包增加稳定环境变量，并统一以归档文件名生成 checksum
- 修正远端部署脚本的 bundle 解压和 checksum 校验逻辑，避免路径不一致导致校验失败
- 在 remote transport 中将远端失败结果转换为阶段化异常，便于调用方及时中断
- 从应用与根包依赖中补齐运行时部署依赖，并为上述行为补充测试

## 测试

- [x] `pnpm test -- test/backend-artifact-builder.test.js test/backend-artifact-remote-script.test.js test/backend-artifact-remote-transport.test.js test/backend-artifact-runtime-package.test.js`

Closes: #20
