### PR TITLE
refactor: enforce strict dx config and dynamic help

### DIFF
--- a/docs/superpowers/plans/2026-04-02-dynamic-cli-help.md
+++ b/docs/superpowers/plans/2026-04-02-dynamic-cli-help.md
@@ -1,0 +1,642 @@
+# Dynamic CLI Help Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace hardcoded CLI help text with config-driven rendering backed by `commands.json`, while keeping command routing, flags, and positional validation grounded in the current code paths.
+
+**Architecture:** Introduce a help pipeline split into schema validation, node classification/model building, and terminal rendering. In phase 1, help text and target descriptions move to `commands.json`, while true command registration, flags, and positional rules remain in code and are pulled into consistency checks so the help layer cannot drift from runtime behavior.
+
+**Tech Stack:** Node.js ESM, existing `dx` CLI router, `commands.json`, Jest, existing CLI integration-style tests.
+
+---
+
+## Chunk 1: Lock Current Behavior and Add New Dynamic Help Fixtures
+
+Dirty worktree note:
+- This repository already contains unrelated in-progress runtime/help changes.
+- Task ownership in this plan is file-scoped.
+- During Task 1/2 review, judge only the files listed in each task’s `Files` block; do not treat pre-existing edits in other files as task-scope violations.
+
+### Task 1: Add failing tests that define the new dynamic help contract
+
+**Files:**
+- Create: `test/dynamic-help-schema.test.js`
+- Create: `test/dynamic-help-renderer.test.js`
+- Modify: `test/start-stack-config.test.js`
+- Reference: `docs/superpowers/specs/2026-04-02-dynamic-cli-help-design.md`
+
+- [ ] **Step 1: Write schema-focused failing tests for help metadata validation**
+
+```js
+import { describe, expect, test } from '@jest/globals'
+
+describe('dynamic help schema', () => {
+  test('rejects unknown help option flags', () => {
+    expect(() => validateHelpConfig({
+      help: {
+        globalOptions: [{ flags: ['--unknown'], description: 'bad' }],
+      },
+    }, { knownFlags: new Map([['--dev', {}]]) })).toThrow('--unknown')
+  })
+
+  test('rejects help examples that reference unknown commands', () => {
+    expect(() => validateHelpConfig({
+      start: {
+        help: {
+          examples: [{ command: 'dx nope x', description: 'bad' }],
+        },
+      },
+    }, { registeredCommands: ['start'] })).toThrow('nope')
+  })
+})
+```
+
+- [ ] **Step 2: Write renderer/model failing tests for visible command and target resolution**
+
+```js
+test('global help uses registered commands instead of raw config roots', () => {})
+test('help model hides internal config bags and category nodes from target list', () => {})
+test('summary prefers help.summary and falls back to description', () => {})
+test('usage falls back to generated usage when help.usage is absent', () => {})
+```
+
+- [ ] **Step 3: Extend the existing start help test to expect dynamic rendering inputs instead of hardcoded `showHelp` strings**
+
+```js
+test('dynamic start help includes stack notes from config help metadata', () => {})
+```
+
+Constraint:
+- `test/start-stack-config.test.js` already contains non-help regression coverage for `start stack` routing and positional validation.
+- Keep those pre-existing runtime regression tests intact.
+- Only append the dynamic help contract assertion needed for this task.
+
+- [ ] **Step 4: Run the focused test files and confirm failure**
+
+Run: `pnpm test -- test/dynamic-help-schema.test.js test/dynamic-help-renderer.test.js test/start-stack-config.test.js`
+Expected: FAIL because no dynamic help schema/model/renderer exists yet.
+
+- [ ] **Step 5: Commit the failing test baseline**
+
+```bash
+git add test/dynamic-help-schema.test.js test/dynamic-help-renderer.test.js test/start-stack-config.test.js
+git commit -m "test: define dynamic cli help contract"
+```
+
+### Task 2: Add minimal help metadata to config fixtures without changing runtime behavior
+
+**Files:**
+- Modify: `dx/config/commands.json`
+- Modify: `example/dx/config/commands.json`
+- Test: `test/dynamic-help-schema.test.js`
+
+- [ ] **Step 1: Add top-level help metadata and command-level help metadata for the first migrated commands**
+
+Configuration shape to add:
+
+```json
+{
+  "help": {
+    "summary": "统一开发环境管理工具",
+    "globalOptions": [
+      { "flags": ["--dev", "--development"], "description": "使用开发环境" },
+      { "flags": ["--prod", "--production"], "description": "使用生产环境" }
+    ],
+    "examples": [
+      { "command": "dx start backend --dev", "description": "启动后端开发服务" }
+    ],
+    "commands": {
+      "start": {
+        "summary": "启动/桥接服务",
+        "notes": [
+          "未指定 service 时默认使用 dev 套件，仅允许 --dev"
+        ],
+        "examples": [
+          { "command": "dx start backend --dev", "description": "启动后端开发服务" },
+          { "command": "dx start stack front", "description": "PM2 服务栈 + Stagewise front" }
+        ]
+      }
+    }
+  }
+}
+```
+
+Important:
+- Do not place phase-1 command help metadata at `start.help` / `deploy.help` / `db.help`.
+- Current runtime treats `start.*` and similar command-tree children as executable nodes, so embedding help there would change runtime behavior.
+
+- [ ] **Step 2: Add explicit `help.nodeType` or `help.expose` only where heuristics would be ambiguous**
+
+Example:
+
+```json
+{
+  "parallelWeb": {
+    "help": {
+      "expose": false
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Keep existing `description` values untouched during this task**
+
+Do not remove or rename `description` yet. This task is only about adding the new help metadata needed for schema/model tests.
+
+- [ ] **Step 4: Re-run the schema test and confirm it still fails on missing validator implementation, not malformed config**
+
+Run: `pnpm test -- test/dynamic-help-schema.test.js`
+Expected: FAIL because validation functions do not exist yet, while JSON remains parseable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dx/config/commands.json example/dx/config/commands.json test/dynamic-help-schema.test.js
+git commit -m "chore: add initial help metadata to command configs"
+```
+
+## Chunk 2: Build the Help Validation and Modeling Pipeline
+
+### Task 3: Implement help schema validation against real command and flag sources
+
+**Files:**
+- Create: `lib/cli/help-schema.js`
+- Modify: `test/dynamic-help-schema.test.js`
+- Reference: `lib/cli/flags.js`
+- Reference: `lib/cli/dx-cli.js`
+
+- [ ] **Step 1: Create a validator entry point that accepts config and runtime-derived registries**
+
+```js
+export function validateHelpConfig(commands, context) {
+  const {
+    registeredCommands = [],
+    knownFlags = new Map(),
+    usageValidator = () => ({ ok: true }),
+    exampleValidator = () => ({ ok: true }),
+  } = context
+}
+```
+
+- [ ] **Step 2: Implement the first-pass structural checks**
+
+Required checks:
+
+```js
+assertString(help.summary, 'help.summary')
+assertArrayOfObjects(help.globalOptions, 'help.globalOptions')
+assertArrayOfObjects(help.examples, 'help.examples')
+assertFlagsExist(option.flags, knownFlags, path)
+assertRegisteredCommand(example.command, registeredCommands, path)
+```
+
+- [ ] **Step 3: Validate examples and usage through injected runtime-aware callbacks**
+
+```js
+const usageResult = usageValidator(commandName, help.usage)
+if (!usageResult.ok) throw new Error(usageResult.reason)
+
+const exampleResult = exampleValidator(example.command)
+if (!exampleResult.ok) throw new Error(exampleResult.reason)
+```
+
+- [ ] **Step 4: Re-run schema tests**
+
+Run: `pnpm test -- test/dynamic-help-schema.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/cli/help-schema.js test/dynamic-help-schema.test.js
+git commit -m "feat: validate dynamic help config against runtime registries"
+```
+
+### Task 4: Implement node classification and help model building
+
+**Files:**
+- Create: `lib/cli/help-model.js`
+- Modify: `test/dynamic-help-renderer.test.js`
+- Reference: `dx/config/commands.json`
+
+- [ ] **Step 1: Implement node classification for the six node types from the spec**
+
+```js
+export function classifyCommandNode(node = {}) {
+  if (node?.help?.nodeType) return node.help.nodeType
+  if (looksLikeInternalConfigBag(node)) return 'internal-config-bag'
+  if (node.command || node.internal) return 'target-leaf'
+  if (node.concurrent || node.sequential) return 'orchestration-node'
+  if (looksLikeEnvContainer(node)) return 'env-container'
+  if (looksLikeCategoryNode(node)) return 'category-node'
+  return 'unknown-node'
+}
+```
+
+- [ ] **Step 2: Add helpers to suppress hidden or non-user-facing nodes**
+
+```js
+export function isVisibleHelpNode(name, node, nodeType) {
+  if (node?.help?.expose === false) return false
+  if (nodeType === 'internal-config-bag') return false
+  if (nodeType === 'category-node') return false
+  return true
+}
+```
+
+- [ ] **Step 3: Build global and command-level help models using registered commands rather than raw config root keys**
+
+```js
+export function getGlobalHelpModel(commands, context) {
+  return {
+    summary: commands.help?.summary ?? '',
+    commands: context.registeredCommands.map(name => getCommandHelpModel(commands, name, context)),
+  }
+}
+```
+
+- [ ] **Step 4: Respect summary fallback rules**
+
+```js
+function resolveSummary(node) {
+  return node?.help?.summary || node?.description || ''
+}
+```
+
+- [ ] **Step 5: Add runtime context helpers needed by the renderer before wiring `help.js`**
+
+Required interface:
+
+```js
+export function buildHelpRuntimeContext(cli) {
+  return {
+    registeredCommands: getRegisteredCommands(cli),
+    knownFlags: cli.getAllowedFlags ? null : null,
+  }
+}
+```
+
+At minimum, this helper must provide:
+- registered top-level commands derived from `DxCli.commandHandlers`
+- a way for schema/model/renderer to access runtime-derived flag knowledge
+
+- [ ] **Step 6: Run focused model/renderer tests**
+
+Run: `pnpm test -- test/dynamic-help-renderer.test.js`
+Expected: PASS for model classification and summary fallback assertions, while CLI integration tests still fail until rendering is wired in.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/cli/help-model.js test/dynamic-help-renderer.test.js
+git commit -m "feat: classify config nodes for dynamic cli help"
+```
+
+## Chunk 3: Migrate Minimum Help Metadata Needed for Dynamic Rendering
+
+### Task 5: Add config help metadata for `start`, `deploy`, and `db` before switching renderers
+
+**Files:**
+- Modify: `dx/config/commands.json`
+- Modify: `example/dx/config/commands.json`
+- Modify: `test/backend-artifact-deploy-routing.test.js`
+- Modify: `test/start-stack-config.test.js`
+- Modify: `test/db-migrate-guard.test.js`
+
+- [ ] **Step 1: Add command-level help metadata for the three initial commands**
+
+For `start`:
+
+```json
+"help": {
+  "commands": {
+    "start": {
+      "summary": "启动/桥接服务",
+      "usage": "dx start <service> [环境标志]",
+      "notes": [
+        "未指定 service 时默认使用 dev 套件，仅允许 --dev"
+      ]
+    }
+  }
+}
+```
+
+For `deploy` and `db`, add equivalent `summary`, `usage`, `notes`, and `examples` under `help.commands`.
+
+- [ ] **Step 2: Add target-level help metadata for the targets that currently rely on hardcoded prose**
+
+Targets to cover first:
+- `start.stack`
+- `start.stagewise-front`
+- `start.stagewise-admin`
+- `deploy.backend`
+- `deploy.telegram-bot`
+- `db.migrate`
+- `db.deploy`
+- `db.script`
+
+Use a phase-1 safe location such as:
+
+```json
+{
+  "help": {
+    "targets": {
+      "deploy": {
+        "backend": {
+          "summary": "构建并部署 backend 制品到远端主机"
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Rework existing tests so they assert config-driven text sources now exist**
+
+Examples:
+
+```js
+expect(output).toContain('dx start stack')
+expect(output).toContain('dx deploy backend --build-only')
+expect(output).toContain('dx db migrate --dev --name init-user-table')
+```
+
+- [ ] **Step 4: Run targeted help/config tests**
+
+Run: `pnpm test -- test/start-stack-config.test.js test/backend-artifact-deploy-routing.test.js test/db-migrate-guard.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dx/config/commands.json example/dx/config/commands.json test/start-stack-config.test.js test/backend-artifact-deploy-routing.test.js test/db-migrate-guard.test.js
+git commit -m "docs: add config help metadata for start deploy db"
+```
+
+## Chunk 4: Replace Hardcoded Help Rendering with the New Pipeline
+
+### Task 6: Add a renderer and swap `help.js` over to dynamic output
+
+**Files:**
+- Create: `lib/cli/help-renderer.js`
+- Modify: `lib/cli/help.js`
+- Modify: `test/dynamic-help-renderer.test.js`
+- Modify: `test/backend-artifact-deploy-routing.test.js`
+- Modify: `test/start-stack-config.test.js`
+
+- [ ] **Step 1: Implement a simple text renderer for global help and single-command help**
+
+```js
+export function renderGlobalHelp(model) {
+  return [
+    '',
+    model.title,
+    '',
+    '命令:',
+    ...model.commands.map(item => `  ${item.name.padEnd(12)} ${item.summary}`),
+  ].join('\n')
+}
+```
+
+- [ ] **Step 2: Refactor `help.js` so it no longer owns the giant hardcoded `switch`**
+
+Implementation shape:
+
+```js
+import { buildHelpRuntimeContext, getGlobalHelpModel, getCommandHelpModel } from './help-model.js'
+import { renderGlobalHelp, renderCommandHelp } from './help-renderer.js'
+
+export function showHelp(cliContext) {
+  const model = getGlobalHelpModel(cliContext.commands, buildHelpRuntimeContext(cliContext))
+  console.log(renderGlobalHelp(model))
+}
+```
+
+- [ ] **Step 3: Keep backward-compatible wrappers while the CLI call sites are being updated**
+
+Use a default path that still works from existing call sites:
+
+```js
+export function showHelp(cliContext = null) { ... }
+export function showCommandHelp(command, cliContext = null) { ... }
+```
+
+- [ ] **Step 4: Rewrite tests that currently assert hardcoded help strings so they assert dynamic content instead**
+
+Required assertions:
+
+```js
+expect(output).toContain('启动/桥接服务')
+expect(output).toContain('dx start backend --dev')
+expect(output).toContain('构建并部署 backend 制品到远端主机')
+```
+
+- [ ] **Step 5: Run focused help tests**
+
+Run: `pnpm test -- test/dynamic-help-renderer.test.js test/backend-artifact-deploy-routing.test.js test/start-stack-config.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/cli/help-renderer.js lib/cli/help.js test/dynamic-help-renderer.test.js test/backend-artifact-deploy-routing.test.js test/start-stack-config.test.js
+git commit -m "feat: render cli help from command config metadata"
+```
+
+### Task 7: Pass real CLI context into help rendering and preserve current `--help` behavior
+
+**Files:**
+- Modify: `lib/cli/dx-cli.js`
+- Modify: `lib/cli/commands/core.js`
+- Modify: `test/bin-unknown-command-fast-fail.test.js`
+- Modify: `test/dynamic-help-renderer.test.js`
+
+- [ ] **Step 1: Update top-level help call sites to pass the current CLI instance**
+
+```js
+if (this.flags.help && this.command && this.command !== 'help') {
+  showCommandHelp(this.command, this)
+} else {
+  showHelp(this)
+}
+```
+
+- [ ] **Step 2: Update `handleHelp` to pass CLI context through**
+
+```js
+export function handleHelp(cli, args = []) {
+  if (args[0]) showCommandHelp(args[0], cli)
+  else showHelp(cli)
+}
+```
+
+- [ ] **Step 3: Keep positional validation unchanged in phase 1**
+
+Do not add `dx help <command> <target>` yet. Preserve the current one-argument rule so this task stays focused on dynamic rendering parity.
+
+- [ ] **Step 4: Re-run focused CLI help tests**
+
+Run: `pnpm test -- test/bin-unknown-command-fast-fail.test.js test/dynamic-help-renderer.test.js`
+Expected: PASS, and unknown command output still ends with a usable global help page.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/cli/dx-cli.js lib/cli/commands/core.js test/bin-unknown-command-fast-fail.test.js test/dynamic-help-renderer.test.js
+git commit -m "refactor: route cli help through live cli context"
+```
+
+## Chunk 5: Add Consistency Checks and Finish Phase-1 Migration
+
+### Task 8: Add runtime-aware consistency tests so config help cannot drift from real CLI rules
+
+**Files:**
+- Create: `test/dynamic-help-consistency.test.js`
+- Modify: `test/dynamic-help-schema.test.js`
+- Reference: `lib/cli/flags.js`
+- Reference: `lib/cli/dx-cli.js`
+
+- [ ] **Step 1: Write consistency tests that parse configured examples against live command and flag registries**
+
+```js
+test('every configured example command uses a registered top-level command', () => {})
+test('every configured option flag exists in FLAG_DEFINITIONS', () => {})
+test('configured usage strings do not contradict positional validation', () => {})
+```
+
+- [ ] **Step 2: Build a minimal helper that tokenizes `dx ...` example strings safely for validation**
+
+Implementation shape for the test helper:
+
+```js
+function parseExampleCommand(commandText) {
+  return shellLikeSplit(commandText)
+}
+```
+
+Required behavior:
+- preserve double-quoted and single-quoted segments as one argument
+- preserve escaped quotes inside quoted segments when present
+- reject unclosed quotes with a descriptive validation error
+
+Do not use `split(/\s+/)` in this task. Current help examples already contain quoted test-name patterns, so whitespace splitting would produce false negatives.
+
+- [ ] **Step 3: Run the new consistency suite**
+
+Run: `pnpm test -- test/dynamic-help-schema.test.js test/dynamic-help-consistency.test.js`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/dynamic-help-consistency.test.js test/dynamic-help-schema.test.js
+git commit -m "test: prevent dynamic help config from drifting from cli rules"
+```
+
+### Task 9: Migrate remaining command help and define phase-1 modeling for non-execution commands
+
+**Files:**
+- Modify: `dx/config/commands.json`
+- Modify: `example/dx/config/commands.json`
+- Modify: `lib/cli/help.js`
+- Modify: `test/dynamic-help-renderer.test.js`
+
+- [ ] **Step 1: Add help metadata for the remaining top-level commands still shown in help**
+
+Commands to cover:
+- `build`
+- `test`
+- `worktree`
+- `clean`
+- `cache`
+- `install`
+- `status`
+- `contracts`
+- `release`
+- `package`
+- `export`
+
+- [ ] **Step 2: Use phase-1 `help-only` command metadata for commands that do not have a natural execution tree in `commands.json`**
+
+Allowed shape:
+
+```json
+{
+  "helpCommands": {
+    "worktree": {
+      "summary": "Git Worktree 管理",
+      "usage": "dx worktree [action] [num...]"
+    }
+  }
+}
+```
+
+Rules:
+- phase 1 允许 `helpCommands` 作为 help-only metadata 区域
+- `help.commands` 与 `helpCommands` 二选一，最终以仓库收敛后的统一命名为准；在本次实现中优先使用 `help.commands`，仅在命令没有对应执行树且迁移风险更低时保留 `helpCommands` 作为兼容过渡
+- `helpCommands` 不参与运行时 target 解析
+- `DxCli.commandHandlers` 仍然是顶层命令真源，`helpCommands` 只补正文
+
+- [ ] **Step 3: Remove the last hardcoded command prose from `lib/cli/help.js`**
+
+Target end state:
+
+```js
+export { showHelp, showCommandHelp } from './help-runtime.js'
+```
+
+or equivalently small wrappers that only build context and call renderer helpers.
+
+- [ ] **Step 4: Run the focused help suite**
+
+Run: `pnpm test -- test/dynamic-help-renderer.test.js test/dynamic-help-consistency.test.js`
+Expected: PASS with no assertions depending on hardcoded help strings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dx/config/commands.json example/dx/config/commands.json lib/cli/help.js test/dynamic-help-renderer.test.js test/dynamic-help-consistency.test.js
+git commit -m "refactor: remove hardcoded cli help text"
+```
+
+### Task 10: Run full verification and document remaining phase-2 work
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-04-02-dynamic-cli-help-design.md`
+- Modify: `docs/superpowers/plans/2026-04-02-dynamic-cli-help.md`
+
+- [ ] **Step 1: Add a short README note about the new help source of truth**
+
+Required note:
+
+```md
+CLI help content now comes from `dx/config/commands.json` help metadata. Top-level command registration, flags, and positional validation remain code-driven in phase 1.
+```
+
+- [ ] **Step 2: Record deferred phase-2 work in the spec/plan**
+
+Deferred items to note:
+- moving command registration into config
+- moving flag definitions into config
+- supporting `dx help <command> <target>`
+
+- [ ] **Step 3: Run full test verification**
+
+Run: `pnpm test`
+Expected: PASS for the full Jest suite.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/superpowers/specs/2026-04-02-dynamic-cli-help-design.md docs/superpowers/plans/2026-04-02-dynamic-cli-help.md
+git commit -m "docs: record dynamic cli help phase one boundaries"
+```
+
+- [ ] **Step 5: Final verification note**
+
+Capture in the final implementation summary:
+- changed files
+- which commands were migrated
+- which runtime sources still remain authoritative in phase 1
+- deferred phase-2 items

--- a/docs/superpowers/specs/2026-04-02-dynamic-cli-help-design.md
+++ b/docs/superpowers/specs/2026-04-02-dynamic-cli-help-design.md
@@ -1,0 +1,688 @@
+# Dynamic CLI Help: 基于 `commands.json` 的单一事实源设计
+
+## 概述
+
+将 dx CLI 的帮助系统从“`lib/cli/help.js` 中硬编码文案”重构为“基于 `dx/config/commands.json` 动态渲染”。执行配置与帮助配置统一放在 `commands.json` 中，CLI 代码只负责读取、校验与渲染。
+
+目标是让 `commands.json` 成为 CLI help 的唯一事实源，避免帮助文档与真实命令配置漂移。
+
+## 背景与问题
+
+当前帮助系统存在两个结构性问题：
+
+1. `showHelp()` / `showCommandHelp()` 维护了大量手写字符串，与真实配置脱节。
+2. 真实可执行 target 来自 `commands.json`，但帮助示例、可用 service、约束说明散落在代码里，容易出现“帮助写了、配置没接上”或“配置改了、帮助没更新”。
+
+这类漂移已经在 `start stack front/admin` 这类别名用法中暴露风险：帮助层与配置层不能保证同步。
+
+## 设计目标
+
+- `commands.json` 成为帮助文案与 target 说明的唯一事实源
+- 帮助内容支持配置化维护：摘要、参数说明、示例、提示文案都可在配置中定义
+- CLI 代码不再手写各命令帮助正文，只负责动态渲染
+- 保持现有命令执行模型不变，帮助系统只读取配置，不改变执行语义
+- 帮助配置具备 schema 校验能力，缺失或错误时快速失败
+- 为后续新增命令/target 提供低维护成本的帮助扩展路径
+
+## 非目标
+
+- 本次设计不修改现有命令执行协议
+- 本次设计不引入新的配置文件，仍复用 `commands.json`
+- 本次设计不尝试自动从 shell command 字符串反推高级语义说明
+- 本次设计不在第一阶段把 flag 定义、命令路由与位置参数校验整体迁入 `commands.json`
+
+## 真实来源边界
+
+本设计需要明确区分“帮助文案来源”和“CLI 语义来源”，否则只会把漂移从 `help.js` 搬到 `commands.json`。
+
+### 第一阶段的来源分工
+
+- `commands.json`
+  - 负责：帮助文案、target 摘要、示例、提示、命令级/target 级说明
+  - 负责：可执行 target 树以及与 target 关联的结构化事实
+- `lib/cli/flags.js`
+  - 负责：真实支持的 flags 与是否需要值
+- `lib/cli/dx-cli.js`
+  - 负责：顶层命令集合、命令路由、位置参数校验、未知参数处理
+- `lib/cli/commands/*.js`
+  - 负责：命令运行时语义与特殊规则
+
+### 对“单一事实源”的修正定义
+
+第一阶段里，“单一事实源”仅指：
+
+- 帮助正文与帮助示例不再写死在 `help.js`
+- target 级帮助描述只在 `commands.json` 维护
+
+以下内容在第一阶段仍以代码为准，帮助系统只能读取和校验，不可自行发明：
+
+- 顶层可用命令集合
+- 可用 flags 集合
+- 位置参数规则
+- 某些命令的特殊运行时限制
+
+### 第二阶段可选演进
+
+若后续希望做到更严格的单一事实源，可再把以下元数据逐步迁入配置：
+
+- 顶层命令注册表
+- flag 定义
+- 位置参数 schema
+
+但这不属于本次设计的首批落地范围。
+
+## 方案选择
+
+### 方案 A：纯推导帮助
+
+只保留执行配置，由 CLI 根据 `command` / `internal` / 环境分支自动推导帮助。
+
+问题：
+- 很多关键语义无法可靠推导，例如默认环境、风险提示、推荐示例
+- 一旦存在别名、隐式规则、限制说明，仍需回到代码里手写
+
+结论：不采用。
+
+### 方案 B：结构化帮助元数据
+
+在 `commands.json` 中引入结构化 `help` 元数据。执行配置与帮助配置共存，CLI 根据统一 schema 渲染帮助页。
+
+优点：
+- 单一事实源
+- 表达力足够
+- 可校验、可测试、可渐进迁移
+
+结论：采用。
+
+### 方案 C：整段帮助全文配置化
+
+把当前 `help.js` 中的大段文本原样迁移到 JSON 中。
+
+问题：
+- 只是把硬编码从 JS 挪到 JSON
+- 结构化价值低，难以做一致性校验
+
+结论：不采用。
+
+## 配置模型
+
+帮助配置分为四层。
+
+### 1. 顶层 `help`
+
+用于 `dx --help` 的全局帮助页。
+
+建议字段：
+
+```json
+{
+  "help": {
+    "summary": "统一开发环境管理工具",
+    "commandOrder": ["start", "build", "deploy", "db", "test", "worktree"],
+    "globalOptions": [
+      {
+        "flags": ["--dev", "--development"],
+        "description": "使用开发环境"
+      }
+    ],
+    "examples": [
+      {
+        "command": "dx start backend --dev",
+        "description": "启动后端开发服务"
+      }
+    ]
+  }
+}
+```
+
+字段说明：
+- `summary`: 顶层摘要
+- `commandOrder`: 一级命令展示顺序
+- `globalOptions`: 全局 flags 展示
+- `examples`: 总帮助页示例
+
+### 2. 一级命令的 `help`
+
+为避免与现有执行树冲突，phase 1 的命令级帮助元数据不直接写入 `start.help` / `deploy.help` 这类运行时可遍历节点，而是放在顶层 `help.commands.<command>` 下。
+
+建议字段：
+
+```json
+{
+  "help": {
+    "commands": {
+      "start": {
+      "summary": "启动/桥接服务",
+      "usage": "dx start <service> [环境标志]",
+      "args": [
+        {
+          "name": "service",
+          "required": false,
+          "description": "由 start.* 配置决定，默认 dev"
+        }
+      ],
+      "notes": [
+        "未指定 service 时默认使用 dev 套件，仅允许 --dev"
+      ],
+      "examples": [
+        {
+          "command": "dx start backend --staging",
+          "description": "使用 staging 环境启动后端"
+        }
+      ]
+      }
+    }
+  }
+}
+```
+
+字段说明：
+- `summary`: 命令摘要
+- `usage`: 用法字符串
+- `args`: 位置参数说明
+- `notes`: 补充规则与限制说明
+- `examples`: 命令级示例
+
+原因：
+- 当前 CLI 会直接遍历并执行 `start.*` / `deploy.*` 下的节点
+- 若把帮助元数据直接放在这些命令树下，会被误当成可执行 target
+- 因此 phase 1 必须使用不会影响运行语义的安全挂载点
+
+### 3. target 节点的 `help`
+
+phase 1 中，target 级帮助元数据也采用安全挂载点，避免污染现有执行树。推荐挂载在顶层 `help.targets.<command>.<target>` 下；若某 target 节点本身不会被运行时误读，也可在后续阶段评估内嵌形式。
+
+建议字段：
+
+```json
+{
+  "help": {
+    "targets": {
+      "deploy": {
+        "backend": {
+        "summary": "构建并部署 backend 制品到远端主机",
+        "notes": [
+          "backend 制品发布目标默认使用 --dev"
+        ],
+        "options": [
+          {
+            "flags": ["--build-only"],
+            "description": "仅构建制品，不执行远端部署"
+          }
+        ],
+        "examples": [
+          {
+            "command": "dx deploy backend --build-only",
+            "description": "仅构建 backend 制品"
+          }
+        ]
+        }
+      }
+    }
+  }
+}
+```
+
+字段说明：
+- `summary`: target 摘要
+- `notes`: target 特有提示
+- `options`: target 级额外选项
+- `examples`: target 级示例
+
+### 4. 可执行配置本身
+
+现有字段继续保留，用于帮助渲染时提取事实信息：
+- `command`
+- `internal`
+- `app`
+- `dangerous`
+- `ports`
+- `dev` / `staging` / `prod` / `test` / `e2e`
+
+CLI 通过这些字段自动渲染：
+- 支持的环境
+- 是否危险
+- 执行类型（shell/internal）
+- target 列表
+
+## 节点类型模型
+
+当前 `commands.json` 并不是规则的两层树，而是“异构命令树”。在实现 `help-model` 之前，必须先定义节点 taxonomy。
+
+### 节点类型
+
+#### 1. `command-root`
+
+顶层命令节点，例如：
+- `start`
+- `build`
+- `deploy`
+- `db`
+
+职责：
+- 挂载该命令的 `help`
+- 挂载其下一级 target / 分类节点
+
+#### 2. `target-leaf`
+
+直接可执行的 target 叶子节点，例如：
+- `build.shared`
+- `start.stagewise-front`
+- `db.generate`
+
+识别特征：
+- 含 `command` 或 `internal`
+- 不只是环境容器
+
+#### 3. `env-container`
+
+按环境分支的 target 容器节点，例如：
+- `build.backend`
+- `start.backend`
+- `db.migrate`
+
+识别特征：
+- 子节点以 `dev/prod/staging/test/e2e` 为主
+- 当前层本身通常不直接执行
+
+#### 4. `orchestration-node`
+
+用于并发/顺序编排的节点，例如：
+- `build.parallelWeb.dev`
+- `build.all.dev`
+- `dev.all`
+
+识别特征：
+- 含 `concurrent` 或 `sequential`
+- 含 `commands`
+
+#### 5. `category-node`
+
+纯分类节点，不直接对应用户 target，例如：
+- `test.e2e`
+- `test.unit`
+
+识别特征：
+- 主要用于第二层分组
+- 下层才是实际 target
+
+#### 6. `internal-config-bag`
+
+internal handler 的私有配置包，例如：
+- `start.stack.stack`
+- `deploy.backend.backendDeploy`
+
+识别特征：
+- 不应直接暴露为帮助 target
+- 只为某个 `internal` 节点提供执行细节
+
+### 渲染规则约束
+
+- `command-root` 一定出现在帮助页导航中
+- `target-leaf` 与 `env-container` 可以作为用户可见 target 展示
+- `orchestration-node` 默认不单独作为推荐 target 展示，除非显式配置 `help.expose = true`
+- `category-node` 用于帮助页分组，不作为最终 target 名称输出
+- `internal-config-bag` 永远不直接展示给用户
+
+### 必要的显式标记
+
+为了避免纯启发式识别出错，建议允许少量显式 help 元数据：
+
+```json
+{
+  "parallelWeb": {
+    "help": {
+      "expose": false
+    }
+  }
+}
+```
+
+```json
+{
+  "e2e": {
+    "help": {
+      "nodeType": "category"
+    }
+  }
+}
+```
+
+默认仍可启发式识别，但当两者冲突时以显式 `help.nodeType` / `help.expose` 为准。
+
+## 推荐的统一字段约定
+
+为避免配置风格失控，建议统一约束如下：
+
+- 所有帮助文案使用结构化字段，不存储整段预排版文本
+- `examples` 必须是对象数组，不允许直接写字符串
+- `args` / `options` 中每一项必须显式包含 `description`
+- `summary` 保持一句话，避免过长段落
+- `notes` 用于限制、约束、默认行为，不用于重复 `summary`
+
+## 字段优先级与回退规则
+
+为避免 `description`、`help.summary`、`usage`、`args` 等字段形成多源冲突，必须定义明确优先级。
+
+### `summary`
+
+- 首选：`help.summary`
+- 回退：`description`
+- 禁止：同时维护两套语义不同的摘要
+
+规则：
+- 若同时存在 `help.summary` 与 `description`，两者语义必须一致
+- 渲染器优先显示 `help.summary`
+- 一致性测试需要校验两者不冲突
+
+### `usage`
+
+- 首选：`help.usage`
+- 回退：由命令注册信息与位置参数规则生成
+
+规则：
+- 若存在 `help.usage`，必须通过位置参数规则校验
+- 若未配置 `help.usage`，渲染器应基于真实命令形态自动生成基础 usage，避免纯手写漂移
+
+### `args`
+
+- 首选：`help.args`
+- 回退：空
+
+规则：
+- `help.args` 负责解释参数含义
+- 参数是否允许、是否必填，不以 `help.args` 为准，而以真实位置参数规则为准
+
+### `options`
+
+- 首选：`help.options` / 顶层 `help.globalOptions`
+- 回退：由 `flags.js` 生成基础 flag 列表
+
+规则：
+- 帮助页中的 option 描述来自配置
+- 可接受哪些 flag、是否需要值，仍以 `flags.js` 为准
+- 若配置中声明了未知 flag，应在 schema/一致性测试中报错
+
+### `examples`
+
+- 首选：`help.examples`
+- 不提供自动推导回退
+
+规则：
+- `example.command` 必须能通过真实命令/flag/位置参数规则的基础校验
+- 示例描述允许自由文案，但示例命令本身必须可解析
+
+## 帮助渲染规则
+
+### `dx --help`
+
+动态展示：
+- CLI 标题与版本
+- 顶层 `help.summary`
+- 顶层命令注册表中的一级命令列表
+- 每个命令的 `help.summary`
+- 全局选项
+- 顶层示例
+
+### `dx help <command>`
+
+动态展示：
+- `usage`
+- `summary`
+- `args`
+- 环境说明
+- target 列表
+- 每个 target 的 `help.summary` 或 `description`
+- `notes`
+- `examples`
+
+### `dx help <command> <target>`
+
+第二阶段支持，动态展示：
+- target 摘要
+- 支持的环境
+- target 级 options
+- target 级 notes
+- target 级 examples
+
+## 顶层命令注册表
+
+由于当前可用顶层命令并不完全等价于 `commands.json` 顶层 key，本设计不允许直接枚举配置根节点作为帮助命令列表。
+
+### 第一阶段方案
+
+顶层命令列表继续以 CLI 注册表为准，即：
+
+- `DxCli.commandHandlers`
+- 以及必要的兼容命令过滤规则
+
+帮助系统从这里拿到真实可见命令列表，再去 `commands.json` 中查找对应帮助配置。
+
+### 过滤规则
+
+- `dev` 虽然存在 handler，但属于兼容入口，不应出现在主帮助命令列表中
+- `help` 自身是系统命令，不需要从 `commands.json` 提供 target 树
+- 某些顶层命令如 `worktree`、`contracts`、`release` 当前没有完整 target 树，也必须能显示帮助
+
+### 第二阶段可选演进
+
+若未来引入显式命令注册配置，可将顶层命令注册表迁入配置。但第一阶段不这么做。
+
+## CLI 代码职责
+
+重构后 CLI 帮助相关逻辑建议拆为三个模块。
+
+### `lib/cli/help-schema.js`
+
+职责：
+- 校验 `commands.json` 中的 help 元数据是否合法
+- 对缺失关键字段、非法字段类型、示例缺少说明等情况快速报错
+
+### `lib/cli/help-model.js`
+
+职责：
+- 将原始 `commands.json` 转换为统一的帮助中间模型
+- 对命令、target、环境支持、危险标记进行归一化
+- 结合真实命令注册表与 flag 定义做一致性校验前预处理
+
+示例接口：
+
+```js
+getGlobalHelpModel(commands)
+getCommandHelpModel(commands, 'start')
+getTargetHelpModel(commands, 'deploy', 'backend')
+```
+
+建议新增：
+
+```js
+getRegisteredCommands(cli)
+classifyCommandNode(node)
+resolveVisibleTargets(commandName, commandConfig)
+```
+
+### `lib/cli/help-renderer.js`
+
+职责：
+- 将中间模型渲染为 CLI 文本输出
+- 控制分节、排序、缩进与展示风格
+
+### `lib/cli/help.js`
+
+职责：
+- 保留为轻量入口
+- 调用 schema/model/renderer
+- 不再维护命令正文字符串
+
+### `lib/cli/dx-cli.js`
+
+第一阶段需要的最小改动：
+- 允许 `help` 命令继续走动态渲染入口
+- 不改变普通命令执行协议
+- 如需支持 `dx help <command> <target>`，必须同步调整：
+  - `handleHelp`
+  - `validatePositionalArgs('help')`
+  - 对应帮助入口参数解析
+
+## 一致性与校验规则
+
+为了避免“配置化后只是把问题搬到 JSON”，建议加以下硬性校验：
+
+1. 每个一级命令必须有 `help.summary`
+2. 每个 `help.examples[]` 必须包含 `command` 与 `description`
+3. `help.args[]` / `help.options[]` 每项必须包含 `name` 或 `flags` 以及 `description`
+4. 标记为 `dangerous: true` 的节点，其帮助输出必须带有统一风险提示
+5. 帮助里引用的 target 必须真实存在于命令树中
+6. 由环境分支推导出的“支持环境”必须与帮助展示一致，不能手写冲突结果
+7. `help.options` / `help.globalOptions` 中声明的 flags 必须都存在于真实 flag 定义中
+8. `help.usage` 必须能通过真实位置参数规则校验
+9. `help.summary` 与 `description` 若同时存在，不得语义冲突
+10. 示例命令必须通过“命令存在 + flag 合法 + 位置参数合法”的基础解析
+
+## 迁移策略
+
+采用渐进迁移，避免一次性重写所有帮助逻辑。
+
+### 第一阶段：建立 schema 与渲染器
+
+- 引入 `help-schema.js`
+- 引入 `help-model.js`
+- 引入 `help-renderer.js`
+- 在顶层 `commands.json` 添加最小 `help` 结构
+- 接入真实命令注册表与 flag 定义，避免帮助系统自行发明 CLI 语义
+
+### 第二阶段：优先迁移复杂命令
+
+优先迁移：
+- `start`
+- `deploy`
+- `db`
+
+原因：
+- 这三类命令约束最多
+- 最容易发生帮助漂移
+- 对新模型的覆盖最完整
+
+### 第三阶段：迁移剩余命令
+
+逐步迁移：
+- `build`
+- `test`
+- `worktree`
+- `clean`
+- `cache`
+- `status`
+- `release`
+- `contracts`
+- `package`
+- `export`
+
+### 第四阶段：删除旧硬编码帮助
+
+- 删除 `help.js` 中大段静态字符串
+- 所有帮助渲染统一走新模型
+- 若决定支持 `dx help <command> <target>`，在此阶段一并收敛 help 参数校验逻辑
+
+## 兼容性策略
+
+- 初始迁移期允许“新旧并存”：若某命令尚未配置 `help` 元数据，可暂时回退到旧帮助逻辑
+- 当核心命令迁移完成后，再移除旧逻辑
+- 顶层帮助页应优先展示已配置 `help.summary` 的命令；缺失时可回退到通用占位文本，但同时输出配置警告
+- 对于当前没有配置树、但已存在顶层 handler 的命令，允许以“代码注册 + 配置帮助”混合模式过渡
+
+## 测试策略
+
+### 1. Schema 测试
+
+验证：
+- `commands.json` 的帮助结构合法
+- 关键字段存在
+- 非法示例、缺失说明、错误字段类型会触发报错
+
+### 2. 帮助模型测试
+
+验证：
+- target 列表提取正确
+- 支持环境推导正确
+- `dangerous` / `internal` / `command` 等事实信息归一化正确
+- 异构节点分类正确，不会把 `category-node` / `internal-config-bag` 误暴露为 target
+
+### 3. 渲染测试
+
+验证：
+- `dx --help`
+- `dx help start`
+- `dx help deploy`
+- `dx help contracts`
+- `dx help release`
+
+输出包含预期 summary、usage、示例、说明。
+
+### 4. 一致性测试
+
+验证：
+- 帮助示例引用的命令与 target 在当前配置中可解析
+- 标记危险的命令输出风险提示
+- target 的帮助摘要与执行节点存在对应关系
+- `help.options` 与真实 flag 定义一致
+- `help.usage` 与真实位置参数规则一致
+
+## 风险与权衡
+
+### 风险 1：`commands.json` 体积增大
+
+帮助元数据进入配置后，文件会更大。
+
+权衡：
+- 增大是可接受代价，因为换来单一事实源
+- 后续若体积过大，可考虑在保持入口不变的前提下按命令拆分配置
+
+### 风险 2：配置灵活度过高导致风格不统一
+
+如果不限制字段风格，帮助结构会逐渐失控。
+
+权衡：
+- 必须配合 schema 和约束测试
+- 保持 `summary / usage / args / notes / examples` 这一最小结构，不鼓励自由扩展
+
+### 风险 3：迁移期新旧逻辑并存
+
+短期内会存在双轨逻辑。
+
+权衡：
+- 这是渐进迁移的必要成本
+- 应在核心命令迁移完成后尽快删除旧逻辑
+
+### 风险 4：异构节点树导致模型误判
+
+如果没有 node taxonomy，帮助系统会把编排节点、分类节点、internal config bag 错当成用户可选目标。
+
+权衡：
+- 必须先实现节点分类，再做目标渲染
+- 必要时允许 `help.nodeType` / `help.expose` 做显式覆盖
+
+### 风险 5：帮助文案与 CLI 真实语义继续分叉
+
+如果 `usage`、`options`、`examples` 只做存在性校验，长期仍会漂移。
+
+权衡：
+- 必须引入基于真实 flag/参数规则的帮助一致性测试
+- 第一阶段不把语义元数据迁入配置，但要把这些代码来源纳入验证链路
+
+## 最终结论
+
+采用“结构化帮助元数据 + 动态渲染”的方案。
+
+具体原则：
+- `commands.json` 承载帮助文案与 target 说明，且与执行配置共存
+- 帮助内容不再在 `help.js` 中硬编码
+- 帮助配置必须结构化、可校验、可测试
+- 命令集合、flag 集合、位置参数规则在第一阶段仍以代码为准
+- CLI 负责读取配置、结合真实命令语义来源做归一化与渲染
+
+phase 1 的重要约束：
+- 命令级帮助元数据放在 `help.commands.<command>`
+- target 级帮助元数据优先放在 `help.targets.<command>.<target>`
+- 不直接向现有执行树节点内嵌 `help`，除非明确验证该节点不会被运行时误执行
+
+该方案能在不改变现有执行模型的前提下，解决帮助系统与真实命令配置漂移的问题，并为后续新增命令/target 提供可维护的扩展路径。

--- a/dx/config/commands.json
+++ b/dx/config/commands.json
@@ -1,44 +1,49 @@
 {
-  "dev": {
-    "backend": {
-      "command": "npx nx dev backend",
-      "app": "backend",
-      "ports": [3000],
-      "description": "启动后端开发服务"
-    },
-    "front": {
-      "command": "npx nx dev front",
-      "app": "front",
-      "ports": [3001],
-      "description": "启动前端开发服务"
-    },
-    "admin": {
-      "command": "npx nx dev admin-front",
-      "app": "admin-front",
-      "ports": [3500],
-      "description": "启动管理后台开发服务"
-    },
-    "telegram-bot": {
-      "command": "npx nx dev telegram-bot",
-      "app": "telegram-bot",
-      "ports": [3003],
-      "description": "启动 Telegram Bot 开发服务 (Vercel Dev)"
-    },
-    "all": {
-      "concurrent": true,
-      "commands": ["dev.backend", "dev.front", "dev.admin"],
-      "description": "同时启动所有开发服务",
-      "interactive": true
+  "help": {
+    "summary": "统一开发环境管理工具",
+    "globalOptions": [
+      {
+        "flags": ["--dev"],
+        "description": "使用开发环境"
+      },
+      {
+        "flags": ["--prod"],
+        "description": "使用生产环境"
+      }
+    ],
+    "examples": [
+      {
+        "command": "dx start backend --dev",
+        "description": "启动后端开发服务"
+      }
+    ],
+    "commands": {
+      "start": {
+        "summary": "启动/桥接服务",
+        "notes": [
+          "未指定 service 时默认使用开发套件，仅允许 --dev"
+        ],
+        "examples": [
+          {
+            "command": "dx start backend --dev",
+            "description": "启动后端开发服务"
+          },
+          {
+            "command": "dx start stack",
+            "description": "PM2 交互式服务栈"
+          }
+        ]
+      }
     }
   },
   "build": {
     "backend": {
-      "dev": {
+      "development": {
         "command": "npx nx build backend --configuration=development",
         "app": "backend",
         "description": "构建后端(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx build backend --configuration=production",
         "app": "backend",
         "description": "构建后端(生产环境)"
@@ -50,31 +55,31 @@
       "skipEnvValidation": true
     },
     "front": {
-      "dev": {
+      "development": {
         "command": "npx nx build front --configuration=development",
         "app": "front",
         "description": "构建前端(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx run front:exportDist",
         "app": "front",
         "description": "构建并导出前端到 dist/front (生产环境)"
       }
     },
     "admin": {
-      "dev": {
+      "development": {
         "command": "npx nx build admin-front --configuration=development",
         "app": "admin-front",
         "description": "构建管理后台(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx build admin-front --configuration=production",
         "app": "admin-front",
         "description": "构建管理后台(生产环境)"
       }
     },
     "mobile": {
-      "dev": {
+      "development": {
         "command": "cd apps/front && APP_ENV=local NEXT_PUBLIC_APP_ENV=local NEXT_CAPACITOR_BUILD=1 pnpm build:mobile && LANG=en_US.UTF-8 npx cap sync android && cd android && ./gradlew assembleDebug && cd .. && mkdir -p public/apk && cp android/app/build/outputs/apk/debug/app-debug.apk public/apk/app-dev.apk",
         "description": "构建连接本机后端的 Android 调试 APK，并复制到 apps/front/public/apk/app-dev.apk"
       },
@@ -82,43 +87,46 @@
         "command": "cd apps/front && VERSION=${ANDROID_VERSION_NAME:-$(node -p \"require('./package.json').version\")} && VERSION_CODE=${ANDROID_VERSION_CODE:-$(date +%s)} && APP_ENV=staging NEXT_PUBLIC_APP_ENV=staging NEXT_CAPACITOR_BUILD=1 pnpm build:mobile && LANG=en_US.UTF-8 npx cap sync android && cd android && ANDROID_VERSION_NAME=$VERSION ANDROID_VERSION_CODE=$VERSION_CODE ./gradlew assembleRelease && cd .. && mkdir -p dist/mobile/staging && cp android/app/build/outputs/apk/release/app-release.apk dist/mobile/staging/app-staging.apk && cp android/app/build/outputs/apk/release/app-release.apk dist/mobile/staging/app-staging-$VERSION.apk",
         "description": "构建连接 Staging 后端的 Android Release APK，并输出到 apps/front/dist/mobile/staging/ 目录（含版本副本，已签名）"
       },
-      "prod": {
+      "production": {
         "command": "cd apps/front && VERSION=${ANDROID_VERSION_NAME:-$(node -p \"require('./package.json').version\")} && VERSION_CODE=${ANDROID_VERSION_CODE:-$(date +%s)} && APP_ENV=production NEXT_PUBLIC_APP_ENV=production NEXT_CAPACITOR_BUILD=1 pnpm build:mobile && LANG=en_US.UTF-8 npx cap sync android && cd android && ANDROID_VERSION_NAME=$VERSION ANDROID_VERSION_CODE=$VERSION_CODE ./gradlew assembleRelease && cd .. && mkdir -p dist/mobile/prod && cp android/app/build/outputs/apk/release/app-release.apk dist/mobile/prod/app-prod.apk && cp android/app/build/outputs/apk/release/app-release.apk dist/mobile/prod/app-prod-$VERSION.apk",
         "description": "构建连接生产后端的 Android Release APK，并输出到 apps/front/dist/mobile/prod/ 目录（含版本副本，已签名）"
       }
     },
     "all": {
-      "dev": {
+      "development": {
         "sequential": true,
-        "commands": ["build.backend.dev", "build.sdk", "build.parallelWeb.dev"],
+        "commands": ["build.backend.development", "build.sdk", "build.parallelWeb.development"],
         "description": "构建所有应用(开发环境，Web并行)"
       },
-      "prod": {
+      "production": {
         "sequential": true,
         "commands": [
-          "build.backend.prod",
+          "build.backend.production",
           "build.sdk",
-          "build.parallelWeb.prod"
+          "build.parallelWeb.production"
         ],
         "description": "构建所有应用(生产环境，Web并行)"
       }
     },
     "parallelWeb": {
-      "dev": {
+      "help": {
+        "expose": false
+      },
+      "development": {
         "concurrent": true,
-        "commands": ["build.shared", "build.front.dev", "build.admin.dev"],
+        "commands": ["build.shared", "build.front.development", "build.admin.development"],
         "description": "并行构建 Web（shared/front/admin 开发环境）"
       },
-      "prod": {
+      "production": {
         "concurrent": true,
-        "commands": ["build.shared", "build.front.prod", "build.admin.prod"],
+        "commands": ["build.shared", "build.front.production", "build.admin.production"],
         "description": "并行构建 Web（shared/front/admin 生产环境）"
       }
     },
     "sdk": {
-      "dev": {
+      "development": {
         "internal": "sdk-build",
-        "args": ["dev"],
+        "args": ["development"],
         "description": "构建 SDK（开发环境，默认在线）",
         "env": {
           "APP_ENV": "development"
@@ -126,14 +134,14 @@
       },
       "staging": {
         "internal": "sdk-build",
-        "args": ["dev"],
+        "args": ["development"],
         "description": "构建 SDK（预发环境，默认在线）",
         "env": {
           "APP_ENV": "staging",
           "NODE_ENV": "production"
         }
       },
-      "prod": {
+      "production": {
         "internal": "sdk-build",
         "args": [],
         "description": "构建 SDK（生产环境，默认在线）",
@@ -144,11 +152,11 @@
       }
     },
     "affected": {
-      "dev": {
+      "development": {
         "command": "npx nx affected -t build --configuration=development --parallel=3",
         "description": "仅构建受影响项目(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx affected -t build --configuration=production --parallel=3",
         "description": "仅构建受影响项目(生产环境)"
       }
@@ -185,7 +193,7 @@
       "description": "生成Prisma客户端"
     },
     "migrate": {
-      "dev": {
+      "development": {
         "command": "npx nx prisma:migrate:dev backend",
         "app": "backend",
         "description": "执行数据库迁移(开发环境)"
@@ -195,7 +203,7 @@
         "app": "backend",
         "description": "执行数据库迁移(E2E测试环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx prisma:migrate:deploy backend",
         "app": "backend",
         "dangerous": true,
@@ -203,7 +211,7 @@
       }
     },
     "deploy": {
-      "dev": {
+      "development": {
         "command": "npx nx prisma:migrate:deploy backend",
         "app": "backend",
         "description": "应用数据库迁移(开发环境)"
@@ -213,7 +221,7 @@
         "app": "backend",
         "description": "应用数据库迁移(E2E测试环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx prisma:migrate:deploy backend",
         "app": "backend",
         "dangerous": true,
@@ -221,7 +229,7 @@
       }
     },
     "reset": {
-      "dev": {
+      "development": {
         "command": "npx nx prisma:migrate:reset backend && npx nx prisma:db:seed backend",
         "app": "backend",
         "dangerous": true,
@@ -233,7 +241,7 @@
         "dangerous": true,
         "description": "重置数据库并填充种子数据(E2E测试环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx prisma:migrate:reset backend",
         "app": "backend",
         "dangerous": true,
@@ -241,7 +249,7 @@
       }
     },
     "seed": {
-      "dev": {
+      "development": {
         "command": "npx nx prisma:db:seed backend",
         "app": "backend",
         "description": "填充数据库(开发环境)"
@@ -251,7 +259,7 @@
         "app": "backend",
         "description": "填充数据库(E2E测试环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx prisma:db:seed backend",
         "app": "backend",
         "description": "填充数据库(生产环境)"
@@ -262,12 +270,12 @@
       "description": "格式化Prisma schema文件"
     },
     "script": {
-      "dev": {
+      "development": {
         "command": "pnpm --filter ./apps/backend exec ts-node --swc -r tsconfig-paths/register prisma/scripts/{SCRIPT_NAME}.ts",
         "app": "backend",
         "description": "运行数据库脚本(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "pnpm --filter ./apps/backend exec ts-node --swc -r tsconfig-paths/register prisma/scripts/{SCRIPT_NAME}.ts",
         "app": "backend",
         "dangerous": true,
@@ -305,26 +313,26 @@
   },
   "start": {
     "backend": {
-      "dev": {
+      "development": {
         "command": "npx nx dev backend",
         "app": "backend",
         "description": "启动后端开发服务（支持热重载）"
       },
-      "prod": {
+      "production": {
         "command": "npx nx start backend",
         "app": "backend",
         "description": "启动后端生产服务"
       }
     },
     "telegram-bot": {
-      "dev": {
+      "development": {
         "command": "pnpm --filter @ai/telegram-bot dev",
         "app": "telegram-bot",
         "ports": [3003],
         "description": "启动 Telegram Bot 开发服务"
       }
     },
-    "dev": {
+    "development": {
       "internal": "start-dev",
       "args": [],
       "description": "启动完整开发环境（集成start-dev.sh功能）",

--- a/dx/demo/README.md
+++ b/dx/demo/README.md
@@ -1,38 +1,262 @@
-# ai-monorepo dx 配置 Demo
+# dx Demo
 
-该目录基于 `/Users/a1/work/ai-monorepo/dx/config` 精简而来，
-用于演示 `dx` 在 pnpm + Nx monorepo 中的最小可读配置方式。
+这个目录是一份给同事直接参考的 `dx` 配置示例。
+
+目标只有一个：
+把 `dx` 在项目里的最小可用配置讲清楚，并且只展示当前已经采用的严格新规范，不保留任何旧兼容写法。
+
+## 这份 Demo 的边界
+
+- 这是 `dx` 配置示例，不是完整业务项目。
+- 这里只演示 `dx/config/*` 应该怎么组织。
+- 这里的环境键只使用：
+  - `development`
+  - `staging`
+  - `production`
+- CLI 环境标志只使用：
+  - `--dev`
+  - `--staging`
+  - `--prod`
+
+不再支持也不推荐以下旧写法：
+
+- `dev` / `prod` 作为配置节点名
+- `--development` / `--production` / `--stage`
+- 任何“自动回退到旧配置”的行为
+
+如果配置不符合规范，当前 `dx` 会直接报错，而不是帮你兼容。
 
 ## 目录结构
 
-- `config/commands.json`
-- `config/env-layers.json`
-- `config/env-policy.jsonc`
-- `.env.development` / `.env.staging` / `.env.production`
-- `.env.development.local.template` / `.env.staging.local.template` / `.env.production.local.template`
+```text
+dx/demo/
+  README.md
+  config/
+    commands.json
+    env-layers.json
+    env-policy.jsonc
+```
 
-## 精简内容
+三份配置各自负责：
 
-- 命令面：仅保留 `start/build/db/deploy/lint/install` 的核心示例
-- 环境层：仅保留 `development/staging/production`
-- 环境变量策略：仅保留少量必需变量和机密字段
-- 新增 `start.stack`（`internal: "pm2-stack"`）示例，支持：
-  - 启动前端口占用清理（`preflight.killPorts`）
-  - PM2 状态重置（`preflight.pm2Reset`）
-  - 前端缓存和 `*.tsbuildinfo` 清理
+- [commands.json](/Users/a1/work/dx/dx/demo/config/commands.json)：定义命令树、执行方式、帮助信息
+- [env-layers.json](/Users/a1/work/dx/dx/demo/config/env-layers.json)：定义每个环境加载哪些 `.env` 文件
+- [env-policy.jsonc](/Users/a1/work/dx/dx/demo/config/env-policy.jsonc)：定义环境变量布局、机密字段和 required 规则
 
-## 本地体验
+## `commands.json` 怎么看
 
-在本仓库根目录执行：
+[commands.json](/Users/a1/work/dx/dx/demo/config/commands.json) 是核心文件。
+
+这里有两类内容：
+
+1. 命令执行配置
+
+例如：
+
+```json
+{
+  "start": {
+    "backend": {
+      "development": {
+        "command": "npx nx dev backend",
+        "app": "backend"
+      },
+      "production": {
+        "command": "npx nx start backend",
+        "app": "backend"
+      }
+    }
+  }
+}
+```
+
+这表示：
+
+- `dx start backend --dev` 走 `start.backend.development`
+- `dx start backend --prod` 走 `start.backend.production`
+
+2. 帮助信息配置
+
+例如：
+
+```json
+{
+  "help": {
+    "summary": "dx demo 配置（严格新规范示例）",
+    "commands": {
+      "start": {
+        "summary": "启动示例服务"
+      }
+    }
+  }
+}
+```
+
+这表示：
+
+- `dx --help`
+- `dx help start`
+
+这些帮助输出会从配置动态生成，而不是从代码里的硬编码文案生成。
+
+## `commands.json` 的规则
+
+这份 demo 里有几个关键约束：
+
+### 1. 环境分支必须写完整名
+
+要写：
+
+```json
+"development": { ... }
+"staging": { ... }
+"production": { ... }
+```
+
+不要写：
+
+```json
+"dev": { ... }
+"prod": { ... }
+```
+
+### 2. CLI 入口统一用短环境标志
+
+命令行里统一写：
+
+```bash
+dx start backend --dev
+dx build all --staging
+dx build backend --prod
+```
+
+### 3. 默认开发套件显式落在 `start.development`
+
+这份 demo 里专门保留了：
+
+```json
+"start": {
+  "development": {
+    "concurrent": true,
+    "commands": [
+      "start.backend.development",
+      "start.front.development",
+      "start.admin.development"
+    ]
+  }
+}
+```
+
+这样：
+
+- `dx start`
+- `dx start --dev`
+
+都能明确落到默认开发套件，而不是依赖任何旧兼容分支。
+
+### 4. `stack` 只支持 `dx start stack`
+
+这份 demo 里演示的是：
+
+```bash
+dx start stack
+```
+
+不再使用任何 `dx start stack front` / `stack admin` 这种旧式兼容入口。
+
+### 5. 帮助信息也必须跟真实命令树一致
+
+帮助里的示例必须是真能执行的命令，不能写“帮助里有、配置里没有”的形式。
+
+## `env-layers.json` 怎么看
+
+[env-layers.json](/Users/a1/work/dx/dx/demo/config/env-layers.json) 只负责一件事：
+定义每个环境加载哪些 `.env` 文件。
+
+当前 demo 是最简单的三层环境：
+
+```json
+{
+  "development": [".env.development", ".env.development.local"],
+  "staging": [".env.staging", ".env.staging.local"],
+  "production": [".env.production", ".env.production.local"]
+}
+```
+
+含义是：
+
+- committed 文件放默认值或占位值
+- `.local` 文件放本机真实值
+
+## `env-policy.jsonc` 怎么看
+
+[env-policy.jsonc](/Users/a1/work/dx/dx/demo/config/env-policy.jsonc) 负责环境变量治理。
+
+这份 demo 展示了三件事：
+
+1. 哪些环境存在
+2. 哪些 key 是机密
+3. 每个 target 在不同环境下要求哪些变量
+
+重点看这几段：
+
+- `environments`
+- `keys.secret`
+- `appToTarget`
+- `targets.*.required`
+
+如果同事要接入新项目，通常最先要改的是：
+
+- `appToTarget`
+- `targets`
+- `keys`
+
+## 最小试跑步骤
+
+在仓库根目录执行：
 
 ```bash
 node ./bin/dx.js --config-dir ./dx/demo/config --help
+node ./bin/dx.js --config-dir ./dx/demo/config help start
 ```
 
-快速试跑建议：
+如果想体验命令解析而不真正接入业务项目，优先看帮助输出即可。
 
-1. 复制本地模板为 `.local` 文件（仅示例，不要提交真实值）。
-2. 把 `.env.*` 中的占位值保留为 `__SET_IN_env.local__`。
-3. 在目标仓库根目录用 `--config-dir` 指向该 demo 配置后执行 `dx start backend --dev`。
+如果要在真实项目里接入：
 
-如果你在实际 `ai-monorepo` 里使用，请把 `--config-dir` 指向该仓库自己的 `dx/config`。
+1. 把 `dx/demo/config` 复制成项目自己的 `dx/config`
+2. 按项目实际 app 名称修改 `commands.json`
+3. 按项目实际环境变量修改 `env-policy.jsonc`
+4. 按项目实际 `.env` 组织修改 `env-layers.json`
+
+## 建议同事怎么改
+
+### 新增一个命令目标
+
+例如新增 `start.worker`：
+
+1. 在 `commands.json` 的 `start` 下增加 `worker`
+2. 明确写出 `development` / `production` 分支
+3. 如果这个目标需要帮助说明，再在 `help.commands.start` 或后续 `help.targets.start.worker` 中补说明
+
+### 新增一个环境变量
+
+1. 先决定这个变量属于哪个 target
+2. 更新 `env-policy.jsonc` 的 `targets.<target>.required`
+3. 如果是机密，再加入 `keys.secret`
+
+### 新增一个帮助示例
+
+直接改 [commands.json](/Users/a1/work/dx/dx/demo/config/commands.json) 里的 `help` 区域，不要去改 CLI 代码。
+
+## 给同事的结论
+
+如果你要在新项目里接 `dx`，直接照着这个 demo 配：
+
+- 命令树看 [commands.json](/Users/a1/work/dx/dx/demo/config/commands.json)
+- 环境层看 [env-layers.json](/Users/a1/work/dx/dx/demo/config/env-layers.json)
+- 环境变量治理看 [env-policy.jsonc](/Users/a1/work/dx/dx/demo/config/env-policy.jsonc)
+
+不要引入任何旧兼容写法。
+
+项目需要什么，就把配置写清楚；写错了就让 `dx` 直接报错，然后改配置。

--- a/dx/demo/config/commands.json
+++ b/dx/demo/config/commands.json
@@ -1,40 +1,132 @@
 {
-  "start": {
-    "backend": {
-      "dev": {
-        "command": "npx nx dev backend",
-        "app": "backend",
-        "ports": [3000],
+  "help": {
+    "summary": "dx demo 配置（严格新规范示例）",
+    "globalOptions": [
+      {
+        "flags": [
+          "--dev"
+        ],
+        "description": "使用 development 环境"
+      },
+      {
+        "flags": [
+          "--staging"
+        ],
+        "description": "使用 staging 环境"
+      },
+      {
+        "flags": [
+          "--prod"
+        ],
+        "description": "使用 production 环境"
+      }
+    ],
+    "examples": [
+      {
+        "command": "dx start backend --dev",
         "description": "启动后端开发服务"
       },
-      "prod": {
+      {
+        "command": "dx build all --prod",
+        "description": "构建全部示例应用"
+      }
+    ],
+    "commands": {
+      "start": {
+        "summary": "启动示例服务",
+        "notes": [
+          "未指定 service 时默认使用开发套件，仅允许 --dev"
+        ],
+        "examples": [
+          {
+            "command": "dx start backend --dev",
+            "description": "启动后端开发服务"
+          },
+          {
+            "command": "dx start stack",
+            "description": "启动 PM2 交互式服务栈"
+          }
+        ]
+      },
+      "build": {
+        "summary": "构建示例应用",
+        "examples": [
+          {
+            "command": "dx build backend --prod",
+            "description": "构建后端生产产物"
+          },
+          {
+            "command": "dx build all --dev",
+            "description": "并发构建 demo 中的全部应用"
+          }
+        ]
+      },
+      "db": {
+        "summary": "执行数据库相关操作",
+        "examples": [
+          {
+            "command": "dx db migrate --dev --name init-user-table",
+            "description": "创建开发环境迁移"
+          }
+        ]
+      }
+    }
+  },
+  "start": {
+    "backend": {
+      "development": {
+        "command": "npx nx dev backend",
+        "app": "backend",
+        "ports": [
+          3000
+        ],
+        "description": "启动后端开发服务"
+      },
+      "production": {
         "command": "npx nx start backend",
         "app": "backend",
         "description": "启动后端生产服务"
       }
     },
     "front": {
-      "dev": {
+      "development": {
         "command": "npx nx dev front",
         "app": "front",
-        "ports": [3001],
+        "ports": [
+          3001
+        ],
         "description": "启动前端开发服务"
       }
     },
     "admin": {
-      "dev": {
+      "development": {
         "command": "npx nx dev admin-front",
         "app": "admin-front",
-        "ports": [3500],
+        "ports": [
+          3500
+        ],
         "description": "启动管理后台开发服务"
       }
     },
     "all": {
-      "dev": {
+      "development": {
         "concurrent": true,
-        "commands": ["start.backend.dev", "start.front.dev", "start.admin.dev"],
+        "commands": [
+          "start.backend.development",
+          "start.front.development",
+          "start.admin.development"
+        ],
         "description": "并发启动 backend/front/admin"
       }
+    },
+    "development": {
+      "concurrent": true,
+      "commands": [
+        "start.backend.development",
+        "start.front.development",
+        "start.admin.development"
+      ],
+      "description": "默认开发套件"
     },
     "stack": {
       "internal": "pm2-stack",
@@ -43,10 +135,18 @@
       "stack": {
         "ecosystemConfig": "ecosystem.config.cjs",
         "pm2Bin": "pnpm pm2",
-        "services": ["backend", "front", "admin"],
+        "services": [
+          "backend",
+          "front",
+          "admin"
+        ],
         "preflight": {
           "pm2Reset": true,
-          "killPorts": [3000, 3001, 3500],
+          "killPorts": [
+            3000,
+            3001,
+            3500
+          ],
           "forcePortCleanup": true,
           "cleanPaths": [
             "apps/front/.next",
@@ -55,45 +155,54 @@
             "dist/admin-front"
           ],
           "cleanTsBuildInfo": true,
-          "cleanTsBuildInfoDirs": ["apps/front", "apps/admin-front"]
+          "cleanTsBuildInfoDirs": [
+            "apps/front",
+            "apps/admin-front"
+          ]
         }
       }
     }
   },
   "build": {
     "backend": {
-      "dev": {
+      "development": {
         "command": "npx nx build backend --configuration=development",
         "app": "backend",
         "description": "构建后端(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx build backend --configuration=production",
         "app": "backend",
         "description": "构建后端(生产环境)"
       }
     },
     "front": {
-      "dev": {
+      "development": {
         "command": "npx nx build front --configuration=development",
         "app": "front",
         "description": "构建前端(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx run front:exportDist",
         "app": "front",
         "description": "构建前端(生产环境)"
       }
     },
     "all": {
-      "dev": {
+      "development": {
         "concurrent": true,
-        "commands": ["build.backend.dev", "build.front.dev"],
+        "commands": [
+          "build.backend.development",
+          "build.front.development"
+        ],
         "description": "并发构建 backend/front(开发环境)"
       },
-      "prod": {
+      "production": {
         "concurrent": true,
-        "commands": ["build.backend.prod", "build.front.prod"],
+        "commands": [
+          "build.backend.production",
+          "build.front.production"
+        ],
         "description": "并发构建 backend/front(生产环境)"
       }
     }
@@ -105,12 +214,12 @@
       "description": "生成 Prisma Client"
     },
     "migrate": {
-      "dev": {
+      "development": {
         "command": "npx nx prisma:migrate:dev backend",
         "app": "backend",
         "description": "创建迁移(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx prisma:migrate:deploy backend",
         "app": "backend",
         "dangerous": true,

--- a/example/README.md
+++ b/example/README.md
@@ -1,178 +1,296 @@
-# dx example
+# dx Example
 
-这个目录是一个“最小可读”的 dx 接入示例，用于演示：
+这个目录是一份“可读、可抄、可改”的 `dx` 接入示例。
 
-- monorepo 需要满足的条件
-- `dx/config/*` 应该如何写
-- `.env.*` 的分层与校验规则
+它的目的不是展示所有能力，而是告诉同事：
 
-注意：这是示例配置，不保证开箱即用跑通（因为不同团队的 nx target/应用名称不同）。你应该按自己的 monorepo 调整 `commands.json` 里的命令。
+- `dx/config/*` 现在应该怎么写
+- 新项目接入时，最小需要改哪些地方
+- 当前 `dx` 只认什么规范，不再兼容什么旧写法
+
+## 这份 Example 的定位
+
+- 这是示例配置，不是完整业务项目。
+- 它展示的是当前推荐的 `dx` 配置结构。
+- 它只保留新规范，不保留任何旧兼容写法。
+
+这里采用的规范是：
+
+- 环境键只使用：
+  - `development`
+  - `staging`
+  - `production`
+  - `test`
+  - `e2e`
+- CLI 环境标志只使用：
+  - `--dev`
+  - `--staging`
+  - `--prod`
+  - `--test`
+  - `--e2e`
+
+不再建议也不再接受：
+
+- `dev` / `prod` 作为配置节点名
+- `--development` / `--production` / `--stage`
+- 任何自动回退到旧配置的行为
+
+如果配置不符合规范，`dx` 应该直接报错，而不是帮你兼容。
 
 ## 目录结构
 
-```
+```text
 example/
+  README.md
   dx/
     config/
       commands.json
       env-layers.json
       env-policy.jsonc
-  .env.development
-  .env.development.local
-  .env.production
-  .env.production.local
 ```
 
-## 快速体验（推荐全局安装）
+这三份配置分别负责：
+
+- [commands.json](/Users/a1/work/dx/example/dx/config/commands.json)
+  命令树、执行方式、帮助信息
+- [env-layers.json](/Users/a1/work/dx/example/dx/config/env-layers.json)
+  每个环境加载哪些 `.env` 文件
+- [env-policy.jsonc](/Users/a1/work/dx/example/dx/config/env-policy.jsonc)
+  环境变量布局、机密约束、required 校验
+
+## 最快体验方式
+
+在仓库根目录执行：
 
 ```bash
-pnpm add -g @ranger1/dx
-
-# 在任意目录执行，显式指定配置目录
-dx --config-dir /absolute/path/to/example/dx/config --help
-dx --config-dir /absolute/path/to/example/dx/config status
+node ./bin/dx.js --config-dir ./example/dx/config --help
+node ./bin/dx.js --config-dir ./example/dx/config help start
+node ./bin/dx.js --config-dir ./example/dx/config help build
 ```
 
-## commands.json 怎么写
+如果只是想理解配置结构，优先看帮助输出，不需要真的去跑业务命令。
 
-dx 的命令配置是一个 JSON 对象（不是代码）。通常会按命令名分组，例如：
+## `commands.json` 怎么理解
 
-- `start.*`：启动服务
-- `build.*`：构建
-- `db.*`：数据库
-- `deploy.*`：部署
+[commands.json](/Users/a1/work/dx/example/dx/config/commands.json) 是最核心的文件。
 
-其中 `start.stack` 可配置为 `internal: "pm2-stack"`，用于 PM2 交互式服务栈，并支持启动前自动清理端口占用与缓存目录。
-`deploy.backend` 也可配置为 `internal: "backend-artifact-deploy"`，用于“本地构建后端制品 + 上传远端 + 远端安装运行依赖并启动”的标准发布流程。
+它同时承载两类内容：
 
-示例（节选，完整见 `example/dx/config/commands.json`）：
+1. 命令执行配置
+2. 帮助输出配置
+
+### 1. 命令执行配置
+
+例如：
 
 ```json
 {
   "start": {
     "backend": {
       "command": "npx nx dev backend",
-      "app": "backend",
-      "ports": [3000]
+      "app": "backend"
     }
   },
   "build": {
     "backend": {
-      "dev": { "command": "npx nx build backend --configuration=development", "app": "backend" },
-      "prod": { "command": "npx nx build backend --configuration=production", "app": "backend" }
-    }
-  },
-  "test": {
-    "e2e": {
-      "backend": {
-        "command": "npx nx test:e2e backend",
-        "app": "backend",
-        "requiresPath": true,
-        "fileCommand": "npx nx test:e2e backend -- {TEST_PATH}"
+      "development": {
+        "command": "npx nx build backend --configuration=development",
+        "app": "backend"
+      },
+      "production": {
+        "command": "npx nx build backend --configuration=production",
+        "app": "backend"
       }
     }
   }
 }
 ```
 
-当某个 E2E target 配置了 `requiresPath: true` 时，`dx test e2e <target>` 只能按文件或目录增量执行。
-例如：`dx test e2e backend apps/backend/e2e/auth`。
-此时不支持 `dx test e2e <target>`、`dx test e2e <target> all` 或 `dx test e2e all` 这类全量运行。
+这表示：
 
-并发/串行编排示例：
+- `dx start backend --dev` 执行 `start.backend`
+- `dx build backend --dev` 执行 `build.backend.development`
+- `dx build backend --prod` 执行 `build.backend.production`
+
+### 2. 帮助输出配置
+
+例如：
 
 ```json
 {
-  "build": {
-    "all": {
-      "dev": {
-        "concurrent": true,
-        "commands": ["build.backend.dev", "build.front.dev"]
+  "help": {
+    "summary": "统一开发环境管理工具",
+    "commands": {
+      "start": {
+        "summary": "启动/桥接服务"
       }
     }
   }
 }
 ```
 
-backend 制品发布示例：
+这表示：
+
+- `dx --help`
+- `dx help start`
+
+不再由代码里的硬编码长文案生成，而是从配置动态渲染。
+
+## `commands.json` 的关键规则
+
+### 1. 环境分支必须写完整名
+
+要写：
 
 ```json
-{
-  "deploy": {
-    "backend": {
-      "internal": "backend-artifact-deploy",
-      "backendDeploy": {
-        "build": {
-          "app": "backend",
-          "distDir": "dist/backend",
-          "versionFile": "apps/backend/package.json",
-          "commands": {
-            "development": "npx nx build backend --configuration=development",
-            "staging": "npx nx build backend --configuration=production",
-            "production": "npx nx build backend --configuration=production"
-          }
-        },
-        "runtime": {
-          "appPackage": "apps/backend/package.json",
-          "rootPackage": "package.json",
-          "lockfile": "pnpm-lock.yaml",
-          "prismaSchemaDir": "apps/backend/prisma/schema",
-          "prismaConfig": "apps/backend/prisma.config.ts",
-          "ecosystemConfig": "ecosystem.config.cjs"
-        },
-        "artifact": {
-          "outputDir": "release/backend",
-          "bundleName": "backend-bundle"
-        },
-        "remote": {
-          "host": "deploy.example.com",
-          "port": 22,
-          "user": "deploy",
-          "baseDir": "/srv/example-app"
-        },
-        "startup": {
-          "mode": "pm2",
-          "serviceName": "backend"
-        }
-      }
-    }
-  }
-}
+"development": { ... }
+"staging": { ... }
+"production": { ... }
 ```
 
-常用命令：
+不要写：
+
+```json
+"dev": { ... }
+"prod": { ... }
+```
+
+### 2. 命令行入口统一用短标志
+
+命令行里统一写：
 
 ```bash
-dx deploy backend --prod
-dx deploy backend --build-only
-dx deploy backend --prod --skip-migration
+dx start backend --dev
+dx build backend --staging
+dx build backend --prod
+dx db migrate --dev --name init-user-table
 ```
 
-补充约束：
+### 3. 默认开发套件必须显式写在 `start.development`
 
-- release `package.json` 默认只带运行时依赖；如果 `prisma` 仅存在于应用 `devDependencies`，dx 会自动保留它，避免远端迁移阶段缺 CLI。
-- 打包前会递归拒绝任何层级的 `.env*` 文件进入制品。
-- 所有本地路径字段都会先约束在项目根目录内，不能通过 `../` 指向仓库外路径。
-- `remote.baseDir` 必须使用绝对路径，并且只允许 `/`、字母、数字、`.`、`_`、`-` 这些字符。
+这份 example 里保留了：
 
-## env-layers.json 怎么写
+```json
+"start": {
+  "development": {
+    "concurrent": true,
+    "commands": [
+      "start.backend",
+      "start.front"
+    ]
+  }
+}
+```
 
-`env-layers.json` 用于定义每个环境加载哪些 `.env.*` 文件：
+这样：
+
+- `dx start`
+- `dx start --dev`
+
+都会明确落到默认开发套件，而不是依赖任何旧兼容入口。
+
+### 4. `stack` 只支持 `dx start stack`
+
+这份 example 里演示的是：
+
+```bash
+dx start stack
+```
+
+不再依赖任何 `dx start stack front` / `stack admin` 这类兼容写法。
+
+### 5. 帮助示例必须与真实命令树一致
+
+帮助里写出来的示例，必须是当前配置真能支撑的命令。
+
+不要写：
+
+- 配置里没有的 target
+- 旧规范标志
+- 已删除的兼容入口
+
+## `env-layers.json` 怎么理解
+
+[env-layers.json](/Users/a1/work/dx/example/dx/config/env-layers.json) 只负责一件事：
+每个环境加载哪些 `.env` 文件。
+
+当前 example 是：
 
 ```json
 {
   "development": [".env.development", ".env.development.local"],
-  "production": [".env.production", ".env.production.local"]
+  "staging": [".env.staging", ".env.staging.local"],
+  "production": [".env.production", ".env.production.local"],
+  "test": [".env.test", ".env.test.local"],
+  "e2e": [".env.e2e", ".env.e2e.local"]
 }
 ```
 
-dx 会按顺序加载，并在执行命令时用 `pnpm exec dotenv ... -- <cmd>` 包裹（因此项目里需要安装 `dotenv-cli`）。
+含义很简单：
 
-## env-policy.jsonc
+- committed 文件放默认值/占位值
+- `.local` 文件放本机真实值
 
-`env-policy.jsonc` 是统一的 env 策略配置：
+## `env-policy.jsonc` 怎么理解
 
-- 机密 key：只能在 `.env.<env>.local` 放真实值；在 `.env.<env>` 中必须存在同名 key 且为占位符 `__SET_IN_env.local__`
-- 必填校验：按环境 + 按 target（端）定义 required keys
+[env-policy.jsonc](/Users/a1/work/dx/example/dx/config/env-policy.jsonc) 负责环境变量治理。
 
-示例配置见 `example/dx/config/env-policy.jsonc`。
+重点看这几块：
+
+- `environments`
+- `keys.secret`
+- `appToTarget`
+- `targets.*.required`
+
+它回答的是：
+
+1. 这个项目有哪些环境
+2. 哪些变量是机密
+3. 哪些变量在哪些环境必须存在
+4. `commands.json` 里的 `app` 应该映射到哪个 target
+
+## 常见接入方式
+
+如果同事要把这份 example 拿去改成自己项目的 `dx/config`，一般按这个顺序做：
+
+1. 先改 [commands.json](/Users/a1/work/dx/example/dx/config/commands.json)
+   把 app 名称、Nx target、启动/构建/部署命令改成项目自己的
+
+2. 再改 [env-policy.jsonc](/Users/a1/work/dx/example/dx/config/env-policy.jsonc)
+   把 `appToTarget`、`targets`、`required` 改成项目自己的变量规则
+
+3. 最后改 [env-layers.json](/Users/a1/work/dx/example/dx/config/env-layers.json)
+   如果项目的 `.env` 组织方式和 example 不同，再调整层级
+
+## 新增配置时怎么做
+
+### 新增一个命令 target
+
+例如新增 `build.worker`：
+
+1. 在 `commands.json` 中找到 `build`
+2. 新增 `worker`
+3. 明确写 `development` / `production` 分支
+4. 如果要展示帮助，再补 `help.commands.build` 或后续 `help.targets.build.worker`
+
+### 新增一个环境变量
+
+1. 先判断它属于哪个 target
+2. 更新 `env-policy.jsonc` 的 `targets.<target>.required`
+3. 如果它是机密，再加到 `keys.secret`
+
+### 新增一个帮助示例
+
+直接改 [commands.json](/Users/a1/work/dx/example/dx/config/commands.json) 的 `help` 区域，不要去改 CLI 代码。
+
+## 给同事的结论
+
+如果你要把 `dx` 接到新项目里，直接照着这份 example 配：
+
+- 命令树看 [commands.json](/Users/a1/work/dx/example/dx/config/commands.json)
+- 环境层看 [env-layers.json](/Users/a1/work/dx/example/dx/config/env-layers.json)
+- 环境变量治理看 [env-policy.jsonc](/Users/a1/work/dx/example/dx/config/env-policy.jsonc)
+
+不要再引入任何旧兼容写法。
+
+项目需要什么，就把配置写清楚；写错了就让 `dx` 直接报错，然后改配置。

--- a/example/dx/config/commands.json
+++ b/example/dx/config/commands.json
@@ -1,4 +1,41 @@
 {
+  "help": {
+    "summary": "统一开发环境管理工具",
+    "globalOptions": [
+      {
+        "flags": ["--dev"],
+        "description": "使用开发环境"
+      },
+      {
+        "flags": ["--prod"],
+        "description": "使用生产环境"
+      }
+    ],
+    "examples": [
+      {
+        "command": "dx start backend --dev",
+        "description": "启动后端开发服务"
+      }
+    ],
+    "commands": {
+      "start": {
+        "summary": "启动/桥接服务",
+        "notes": [
+          "未指定 service 时默认使用开发套件，仅允许 --dev"
+        ],
+        "examples": [
+          {
+            "command": "dx start backend --dev",
+            "description": "启动后端开发服务"
+          },
+          {
+            "command": "dx start stack",
+            "description": "PM2 交互式服务栈"
+          }
+        ]
+      }
+    }
+  },
   "start": {
     "backend": {
       "command": "npx nx dev backend",
@@ -17,6 +54,11 @@
       "commands": ["start.backend", "start.front"],
       "description": "并发启动 backend/front"
     },
+    "development": {
+      "concurrent": true,
+      "commands": ["start.backend", "start.front"],
+      "description": "默认开发套件"
+    },
     "stack": {
       "internal": "pm2-stack",
       "interactive": true,
@@ -33,38 +75,38 @@
   },
   "build": {
     "backend": {
-      "dev": {
+      "development": {
         "command": "npx nx build backend --configuration=development",
         "app": "backend",
         "description": "构建后端(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx build backend --configuration=production",
         "app": "backend",
         "description": "构建后端(生产环境)"
       }
     },
     "front": {
-      "dev": {
+      "development": {
         "command": "npx nx build front --configuration=development",
         "app": "front",
         "description": "构建前端(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx build front --configuration=production",
         "app": "front",
         "description": "构建前端(生产环境)"
       }
     },
     "all": {
-      "dev": {
+      "development": {
         "concurrent": true,
-        "commands": ["build.backend.dev", "build.front.dev"],
+        "commands": ["build.backend.development", "build.front.development"],
         "description": "并发构建 backend/front(开发环境)"
       },
-      "prod": {
+      "production": {
         "concurrent": true,
-        "commands": ["build.backend.prod", "build.front.prod"],
+        "commands": ["build.backend.production", "build.front.production"],
         "description": "并发构建 backend/front(生产环境)"
       }
     }
@@ -76,12 +118,12 @@
       "description": "生成 Prisma Client"
     },
     "migrate": {
-      "dev": {
+      "development": {
         "command": "npx nx prisma:migrate:dev backend",
         "app": "backend",
         "description": "创建迁移(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx prisma:migrate:deploy backend",
         "app": "backend",
         "dangerous": true,
@@ -89,12 +131,12 @@
       }
     },
     "deploy": {
-      "dev": {
+      "development": {
         "command": "npx nx prisma:migrate:deploy backend",
         "app": "backend",
         "description": "应用迁移(开发环境)"
       },
-      "prod": {
+      "production": {
         "command": "npx nx prisma:migrate:deploy backend",
         "app": "backend",
         "dangerous": true,

--- a/lib/cli/commands/core.js
+++ b/lib/cli/commands/core.js
@@ -6,13 +6,8 @@ import { execManager } from '../../exec.js'
 import { showHelp, showCommandHelp } from '../help.js'
 
 export function handleHelp(cli, args = []) {
-  void cli
-  if (args[0]) showCommandHelp(args[0])
-  else showHelp()
-}
-
-export function handleDev(cli, args = []) {
-  return cli.reportDevCommandRemoved(args)
+  if (args[0]) showCommandHelp(args[0], cli)
+  else showHelp(cli)
 }
 
 export async function handleBuild(cli, args) {
@@ -24,12 +19,6 @@ export async function handleBuild(cli, args) {
 
   const buildConfig = cli.commands.build[target]
   if (!buildConfig) {
-    // 兼容用户误输入或快捷命令，把 "all./scripts/dx" 这类粘连错误拆分
-    const fixed = String(target).split(/\s|\t|\r|\n|\u00A0|\.|\//)[0]
-    if (fixed && cli.commands.build[fixed]) {
-      logger.warn(`自动修正构建目标: ${target} -> ${fixed}`)
-      return await handleBuild(cli, [fixed])
-    }
     logger.error(`未找到构建目标: ${target}`)
     process.exitCode = 1
     return
@@ -40,14 +29,12 @@ export async function handleBuild(cli, args) {
   // 处理嵌套配置
   let config = buildConfig
   if (typeof config === 'object' && !config.command) {
-    const supportsCurrentEnv = Boolean(
-      config[envKey] || (envKey === 'staging' && config.prod),
-    )
+    const supportsCurrentEnv = Boolean(config[envKey])
     if (explicitEnv && !supportsCurrentEnv) {
       const envFlag = cli.getEnvironmentFlagExample(envKey) || `--${envKey}`
       logger.error(`构建目标 ${target} 不支持 ${envFlag} 环境`)
       logger.info('显式传入环境标志时，必须是该 target 实际支持的环境。')
-      const available = ['dev', 'staging', 'prod', 'test', 'e2e']
+      const available = ['development', 'staging', 'production', 'test', 'e2e']
         .filter(key => key in config)
         .map(key => cli.getEnvironmentFlagExample(key) || `--${key}`)
       if (available.length > 0) {
@@ -61,10 +48,15 @@ export async function handleBuild(cli, args) {
       return
     }
 
-    // 如果是嵌套配置，尝试获取环境特定的配置（兼容 dev/prod 与 development/production 命名）
+    // 严格按显式环境选择配置，不做环境回退
     if (config[envKey]) config = config[envKey]
-    else if (envKey === 'staging' && config.prod) config = config.prod
-    else config = config.dev || config
+    else config = null
+  }
+
+  if (!config) {
+    logger.error(`构建目标 ${target} 未提供 ${cli.getEnvironmentFlagExample(envKey) || envKey} 环境配置`)
+    process.exitCode = 1
+    return
   }
 
   if (config.concurrent) {

--- a/lib/cli/commands/db.js
+++ b/lib/cli/commands/db.js
@@ -22,7 +22,7 @@ export async function handleDatabase(cli, args) {
   const envKey = cli.normalizeEnvKey(environment)
 
   // 创建迁移只允许在开发环境进行，避免 AI/用户在非开发环境误执行
-  if (action === 'migrate' && envKey && envKey !== 'dev') {
+  if (action === 'migrate' && envKey && envKey !== 'development') {
     const envFlag = cli.getEnvironmentFlagExample(envKey) || `--${envKey}`
     logger.error('dx db migrate 仅允许在 --dev 环境下创建迁移')
     logger.info('请使用 `dx db migrate --dev --name <migration-name>` 创建新迁移。')
@@ -49,10 +49,15 @@ export async function handleDatabase(cli, args) {
   // 处理嵌套配置
   let config = dbConfig
   if (typeof config === 'object' && !config.command) {
-    // 如果是嵌套配置，尝试获取环境特定的配置（兼容 dev/prod 与 development/production 命名）
+    // 严格按显式环境选择配置，不做环境回退
     if (config[envKey]) config = config[envKey]
-    else if (envKey === 'staging' && config.prod) config = config.prod
-    else config = config.dev || config
+    else config = null
+  }
+
+  if (!config) {
+    logger.error(`数据库操作 ${action} 未提供 ${cli.getEnvironmentFlagExample(envKey) || envKey} 环境配置`)
+    process.exitCode = 1
+    return
   }
 
   // 危险操作确认
@@ -71,7 +76,7 @@ export async function handleDatabase(cli, args) {
 
   // 支持为 migrate 传入迁移名：--name/-n
   let command = config.command
-  if (action === 'migrate' && envKey === 'dev') {
+  if (action === 'migrate' && envKey === 'development') {
     const allArgs = cli.args
     let migrationName = null
     // 优先解析显式标志 --name/-n
@@ -123,24 +128,14 @@ export async function handleDatabase(cli, args) {
       .join('')
   }
 
-  if (action === 'reset' && envKey !== 'prod') {
+  if (action === 'reset' && envKey !== 'production') {
     extraEnv.PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION = 'yes'
     logger.info('非生产环境重置数据库，已自动确认危险操作: PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes')
   }
 
-  const execFlags = { ...cli.flags }
-  ;['dev', 'development', 'prod', 'production', 'test', 'e2e', 'staging', 'stage'].forEach(
-    key => delete execFlags[key],
-  )
-  if (envKey === 'prod') execFlags.prod = true
-  else if (envKey === 'dev') execFlags.dev = true
-  else if (envKey === 'test') execFlags.test = true
-  else if (envKey === 'e2e') execFlags.e2e = true
-  else if (envKey === 'staging') execFlags.staging = true
-
   await cli.executeCommand(
     { ...config, command, env: { ...(config.env || {}), ...extraEnv } },
-    execFlags,
+    cli.createExecutionFlags(environment),
   )
 }
 
@@ -177,7 +172,7 @@ export async function handleDatabaseScript(cli, scriptName, envKey, dbConfig) {
     return
   }
 
-  const environment = envKey === 'dev' ? 'development' : envKey === 'prod' ? 'production' : envKey
+  const environment = envKey
   logger.step(`执行数据库脚本: ${cleanScriptName} (${environment})`)
   logger.info(`脚本路径: ${scriptPath}`)
 
@@ -185,12 +180,17 @@ export async function handleDatabaseScript(cli, scriptName, envKey, dbConfig) {
   let config = dbConfig
   if (typeof config === 'object' && !config.command) {
     if (config[envKey]) config = config[envKey]
-    else if (envKey === 'staging' && config.prod) config = config.prod
-    else config = config.dev || config
+    else config = null
+  }
+
+  if (!config) {
+    logger.error(`数据库脚本 ${scriptName} 未提供 ${cli.getEnvironmentFlagExample(envKey) || envKey} 环境配置`)
+    process.exitCode = 1
+    return
   }
 
   // 危险操作确认
-  if (config.dangerous && envKey === 'prod') {
+  if (config.dangerous && envKey === 'production') {
     const confirmed = await confirmManager.confirmDatabaseOperation(
       `script: ${cleanScriptName}`,
       envManager.getEnvironmentDescription(environment),
@@ -224,18 +224,8 @@ export async function handleDatabaseScript(cli, scriptName, envKey, dbConfig) {
   const extraEnv = { NX_CACHE: 'false' }
   logger.info('为数据库脚本禁用 Nx 缓存: NX_CACHE=false')
 
-  const execFlags = { ...cli.flags }
-  ;['dev', 'development', 'prod', 'production', 'test', 'e2e', 'staging', 'stage'].forEach(
-    key => delete execFlags[key],
-  )
-  if (envKey === 'prod') execFlags.prod = true
-  else if (envKey === 'dev') execFlags.dev = true
-  else if (envKey === 'test') execFlags.test = true
-  else if (envKey === 'e2e') execFlags.e2e = true
-  else if (envKey === 'staging') execFlags.staging = true
-
   await cli.executeCommand(
     { ...config, command, env: { ...(config.env || {}), ...extraEnv } },
-    execFlags,
+    cli.createExecutionFlags(environment),
   )
 }

--- a/lib/cli/commands/export.js
+++ b/lib/cli/commands/export.js
@@ -25,8 +25,13 @@ export async function handleExport(cli, args) {
   let config = exportConfig
   if (typeof config === 'object' && !config.command) {
     if (config[envKey]) config = config[envKey]
-    else if (envKey === 'staging' && config.prod) config = config.prod
-    else config = config.dev || config
+    else config = null
+  }
+
+  if (!config) {
+    logger.error(`导出目标 ${target} 未提供 ${cli.getEnvironmentFlagExample(envKey) || envKey} 环境配置`)
+    process.exitCode = 1
+    return
   }
 
   logger.step(`导出 ${target} (${environment})`)

--- a/lib/cli/commands/start.js
+++ b/lib/cli/commands/start.js
@@ -1,24 +1,11 @@
 import { logger } from '../../logger.js'
 
 export async function handleStart(cli, args) {
-  const service = args[0] || 'dev'
+  const service = args[0] || 'development'
 
   const environment = cli.determineEnvironment()
   const envKey = cli.normalizeEnvKey(environment)
-
-  let rawConfig = cli.commands.start[service]
-  let configNamespace = 'start'
-
-  if (!rawConfig && cli.commands.dev?.[service]) {
-    if (envKey !== 'dev') {
-      logger.error(`目标 ${service} 仅支持开发环境启动，请使用 --dev 或省略环境标志。`)
-      process.exitCode = 1
-      return
-    }
-    rawConfig = cli.commands.dev[service]
-    configNamespace = 'dev'
-    logger.info(`检测到 legacy "dev" 配置，已自动回退至 ${service} 开发脚本。`)
-  }
+  const rawConfig = cli.commands.start[service]
 
   if (!rawConfig) {
     logger.error(`未找到启动配置: ${service}`)
@@ -27,13 +14,17 @@ export async function handleStart(cli, args) {
   }
 
   let startConfig = rawConfig
-  if (configNamespace === 'start' && rawConfig && typeof rawConfig === 'object') {
-    if (rawConfig[envKey]) startConfig = rawConfig[envKey]
-    else if (envKey === 'staging' && rawConfig?.prod) startConfig = rawConfig.prod
+  const isRunnableConfig =
+    rawConfig &&
+    typeof rawConfig === 'object' &&
+    (rawConfig.command || rawConfig.internal || rawConfig.concurrent || rawConfig.sequential)
+
+  if (!isRunnableConfig && rawConfig && typeof rawConfig === 'object') {
+    startConfig = rawConfig[envKey] || null
   }
 
   if (!startConfig) {
-    logger.error(`启动目标 ${service} 未提供 ${environment} 环境配置。`)
+    logger.error(`启动目标 ${service} 未提供 ${cli.getEnvironmentFlagExample(envKey) || envKey} 环境配置。`)
     process.exitCode = 1
     return
   }
@@ -41,7 +32,7 @@ export async function handleStart(cli, args) {
   logger.step(`启动 ${service} 服务 (${environment})`)
 
   if (startConfig.concurrent && Array.isArray(startConfig.commands)) {
-    await cli.handleConcurrentCommands(startConfig.commands, configNamespace, envKey)
+    await cli.handleConcurrentCommands(startConfig.commands, 'start', envKey)
     return
   }
 
@@ -52,26 +43,16 @@ export async function handleStart(cli, args) {
 
   const ports = cli.collectStartPorts(service, startConfig, envKey)
 
-  if (envKey === 'dev' && ports.length > 0) {
+  if (envKey === 'development' && ports.length > 0) {
     logger.info(`开发环境自动清理端口: ${ports.join(', ')}`)
   }
 
   const configToExecute = {
     ...startConfig,
     ...(ports.length > 0 ? { ports } : {}),
-    ...(envKey === 'dev' ? { forcePortCleanup: true } : {}),
+    ...(envKey === 'development' ? { forcePortCleanup: true } : {}),
   }
 
   // 为执行阶段构造环境标志，确保 dotenv 选择正确层
-  const execFlags = { ...cli.flags }
-  ;['dev', 'development', 'prod', 'production', 'test', 'e2e', 'staging', 'stage'].forEach(
-    key => delete execFlags[key]
-  )
-  if (envKey === 'prod') execFlags.prod = true
-  else if (envKey === 'dev') execFlags.dev = true
-  else if (envKey === 'test') execFlags.test = true
-  else if (envKey === 'e2e') execFlags.e2e = true
-  else if (envKey === 'staging') execFlags.staging = true
-
-  await cli.executeCommand(configToExecute, execFlags)
+  await cli.executeCommand(configToExecute, cli.createExecutionFlags(environment))
 }

--- a/lib/cli/commands/worktree.js
+++ b/lib/cli/commands/worktree.js
@@ -64,8 +64,6 @@ export async function handleWorktree(cli, args) {
       break
 
     case 'del':
-    case 'delete':
-    case 'rm':
       // 互斥校验：--all 不能与 issue 编号同时使用
       // args[0] 是 action，args[1] 开始才是 issue 编号
       if (cli.flags.all && args.length > 1) {
@@ -131,12 +129,10 @@ export async function handleWorktree(cli, args) {
       break
 
     case 'list':
-    case 'ls':
       await worktreeManager.list()
       break
 
     case 'clean':
-    case 'prune':
       await worktreeManager.clean()
       break
 

--- a/lib/cli/dx-cli.js
+++ b/lib/cli/dx-cli.js
@@ -13,10 +13,10 @@ import {
 import { FLAG_DEFINITIONS, parseFlags } from './flags.js'
 import { getCleanArgs, getCleanArgsWithConsumedValues } from './args.js'
 import { showHelp, showCommandHelp } from './help.js'
+import { buildStrictHelpValidationContext, validateHelpConfig } from './help-schema.js'
 import { getPackageVersion } from '../version.js'
 import {
   handleHelp,
-  handleDev,
   handleBuild,
   handleTest,
   handleLint,
@@ -51,7 +51,6 @@ class DxCli {
     this.envCache = null
     this.commandHandlers = {
       help: args => handleHelp(this, args),
-      dev: args => handleDev(this, args),
       start: args => handleStart(this, args),
       build: args => handleBuild(this, args),
       test: args => handleTest(this, args),
@@ -70,6 +69,7 @@ class DxCli {
     }
 
     this.flagDefinitions = FLAG_DEFINITIONS
+    this.validateLoadedHelpConfig()
   }
 
   // 加载命令配置
@@ -82,6 +82,10 @@ class DxCli {
       logger.error(error?.message || String(error))
       process.exit(1)
     }
+  }
+
+  validateLoadedHelpConfig() {
+    validateHelpConfig(this.commands, buildStrictHelpValidationContext(this))
   }
 
   // 检测并安装依赖
@@ -172,22 +176,9 @@ class DxCli {
           throw new Error('未找到 db.generate 命令配置，请检查 dx/config/commands.json')
         }
 
-        const envKey = this.normalizeEnvKey(environment)
-        const execFlags = { ...this.flags }
-        ;['dev', 'development', 'prod', 'production', 'test', 'e2e', 'staging', 'stage'].forEach(
-          key => {
-            delete execFlags[key]
-          },
-        )
-        if (envKey === 'prod') execFlags.prod = true
-        else if (envKey === 'dev') execFlags.dev = true
-        else if (envKey === 'test') execFlags.test = true
-        else if (envKey === 'e2e') execFlags.e2e = true
-        else if (envKey === 'staging') execFlags.staging = true
-
         await execManager.executeCommand(generateConfig.command, {
           app: generateConfig.app || 'backend',
-          flags: execFlags,
+          flags: this.createExecutionFlags(environment),
           // Prisma generate 不应卡在环境变量校验上
           skipEnvValidation: true,
         })
@@ -286,9 +277,9 @@ class DxCli {
       // 显示帮助
       if (this.flags.help || !this.command) {
         if (this.flags.help && this.command && this.command !== 'help') {
-          showCommandHelp(this.command)
+          showCommandHelp(this.command, this)
         } else {
-          showHelp()
+          showHelp(this)
         }
         return
       }
@@ -298,7 +289,7 @@ class DxCli {
       // Fail fast for unknown commands before dependency/env startup checks.
       if (this.command && !this.commandHandlers[this.command]) {
         logger.error(`未知命令: ${this.command}`)
-        showHelp()
+        showHelp(this)
         process.exit(1)
       }
 
@@ -346,7 +337,7 @@ class DxCli {
     const [, ...subArgs] = cleanArgs
 
     if (!command) {
-      showHelp()
+      showHelp(this)
       return
     }
 
@@ -504,14 +495,14 @@ class DxCli {
       case 'worktree': {
         if (positionalArgs.length === 0) return
         const action = positionalArgs[0]
-        if (['del', 'delete', 'rm'].includes(action)) {
+        if (action === 'del') {
           return
         }
-        if (['make'].includes(action)) {
+        if (action === 'make') {
           ensureMax(3)
           break
         }
-        if (['list', 'ls', 'clean', 'prune'].includes(action)) {
+        if (action === 'list' || action === 'clean') {
           ensureMax(1)
           break
         }
@@ -550,11 +541,8 @@ class DxCli {
     const value = String(token).toLowerCase()
     return (
       value === 'dev' ||
-      value === 'development' ||
       value === 'prod' ||
-      value === 'production' ||
       value === 'staging' ||
-      value === 'stage' ||
       value === 'test' ||
       value === 'e2e'
     )
@@ -570,18 +558,19 @@ class DxCli {
     if (suggestion) {
       logger.info(`建议命令: ${suggestion}`)
     } else if (normalizedFlag) {
-    logger.info(`示例: ${this.invocation} ${command} ... ${normalizedFlag}`)
+      logger.info(`示例: ${this.invocation} ${command} ... ${normalizedFlag}`)
     }
     logger.info('未显式指定环境时将默认使用 --dev。')
     process.exit(1)
   }
 
   getEnvironmentFlagExample(token) {
-    const key = this.normalizeEnvKey(token)
-    switch (key) {
+    switch (String(token || '').toLowerCase()) {
       case 'dev':
+      case 'development':
         return '--dev'
       case 'prod':
+      case 'production':
         return '--prod'
       case 'staging':
         return '--staging'
@@ -634,13 +623,13 @@ class DxCli {
   }
 
   validateStartPositionals(positionalArgs) {
-    const service = positionalArgs[0] || 'dev'
+    const service = positionalArgs[0] || 'development'
     const environment = this.determineEnvironment()
     const envKey = this.normalizeEnvKey(environment)
 
-    if (service === 'dev' && envKey !== 'dev') {
+    if (service === 'development' && envKey !== 'development') {
       logger.error('dx start 在未指定服务时仅允许使用开发环境')
-      logger.info(`示例: ${this.invocation} start all --dev`)
+      logger.info(`示例: ${this.invocation} start --dev`)
       logger.info(`示例: ${this.invocation} start backend --prod`)
       process.exit(1)
     }
@@ -649,7 +638,7 @@ class DxCli {
     if (!startConfig) return
 
     // 对 start 下的单层 command 配置，默认视为开发态目标，仅允许 --dev。
-    if (startConfig.command && envKey !== 'dev') {
+    if (startConfig.command && envKey !== 'development') {
       logger.error(`启动目标 ${service} 仅支持开发环境`)
       logger.info(`示例: ${this.invocation} start ${service} --dev`)
       process.exit(1)
@@ -669,13 +658,13 @@ class DxCli {
     const buildConfig = this.commands?.build?.[target]
     if (!buildConfig || buildConfig.command) return
 
-    const supportsCurrentEnv = Boolean(buildConfig[envKey] || (envKey === 'staging' && buildConfig.prod))
+    const supportsCurrentEnv = Boolean(buildConfig[envKey])
     if (supportsCurrentEnv) return
 
     const envFlag = this.getEnvironmentFlagExample(envKey) || `--${envKey}`
     logger.error(`构建目标 ${target} 不支持 ${envFlag} 环境`)
     logger.info('显式传入环境标志时，必须是该 target 实际支持的环境。')
-    const available = ['dev', 'staging', 'prod', 'test', 'e2e']
+    const available = ['development', 'staging', 'production', 'test', 'e2e']
       .filter(key => key in buildConfig)
       .map(key => this.getEnvironmentFlagExample(key) || `--${key}`)
     if (available.length > 0) {
@@ -684,19 +673,6 @@ class DxCli {
       if (available.length > 1) {
         logger.info(`示例: ${this.invocation} build ${target} ${available[1]}`)
       }
-    }
-    process.exit(1)
-  }
-
-  reportDevCommandRemoved(args) {
-    const target = args?.[0]
-    logger.error('`dx dev` 命令已移除，统一使用 `dx start`。')
-    if (target) {
-      logger.info(`请执行: ${this.invocation} start ${target} --dev`)
-    } else {
-      logger.info(`示例: ${this.invocation} start backend --dev`)
-      logger.info(`      ${this.invocation} start front --dev`)
-      logger.info(`      ${this.invocation} start admin --dev`)
     }
     process.exit(1)
   }
@@ -772,7 +748,7 @@ class DxCli {
         continue
       }
       commands.push({
-        command: this.applySdkOfflineFlag(config.command),
+        command: config.command,
         options: {
           app: config.app,
           ports: config.ports,
@@ -820,20 +796,9 @@ class DxCli {
     if (environment && config) {
       const envKey = this.normalizeEnvKey(environment)
       if (config[envKey]) config = config[envKey]
-      else if (envKey === 'staging' && config.prod) config = config.prod
     }
 
     return config
-  }
-
-  // SDK 构建命令当前不再暴露 --online/--offline 模式，保留该方法仅为兼容旧调用
-  applySdkModeFlags(command) {
-    return command
-  }
-
-  // 向后兼容的别名
-  applySdkOfflineFlag(command) {
-    return command
   }
 
   collectStartPorts(service, startConfig, envKey) {
@@ -843,15 +808,6 @@ class DxCli {
       startConfig.ports.forEach(port => {
         this.addPortToSet(portSet, port)
       })
-    }
-
-    if (envKey === 'dev') {
-      const legacyConfig = this.commands.dev?.[service]
-      if (legacyConfig && Array.isArray(legacyConfig.ports)) {
-        legacyConfig.ports.forEach(port => {
-          this.addPortToSet(portSet, port)
-        })
-      }
     }
 
     return Array.from(portSet)
@@ -936,28 +892,6 @@ class DxCli {
     }
 
     const rawCommand = String(config.command).trim()
-    // backward compat: old commands.json referenced scripts/lib/*.js in the project
-    if (rawCommand.startsWith('node scripts/lib/sdk-build.js')) {
-      const argsText = rawCommand.replace(/^node\s+scripts\/lib\/sdk-build\.js\s*/g, '')
-      const args = argsText ? argsText.split(/\s+/).filter(Boolean) : []
-      await withTempEnv(async () => {
-        const { runSdkBuild } = await import('../sdk-build.js')
-        await runSdkBuild(args)
-      })
-      return
-    }
-
-    if (rawCommand.startsWith('node scripts/lib/backend-package.js')) {
-      const argsText = rawCommand.replace(/^node\s+scripts\/lib\/backend-package\.js\s*/g, '')
-      const args = argsText ? argsText.split(/\s+/).filter(Boolean) : []
-      await withTempEnv(async () => {
-        const { runBackendPackage } = await import('../backend-package.js')
-        await runBackendPackage(args)
-      })
-      return
-    }
-
-    const command = this.applySdkOfflineFlag(rawCommand)
 
     const options = {
       app: config.app,
@@ -969,7 +903,7 @@ class DxCli {
       forcePortCleanup: Boolean(config.forcePortCleanup),
     }
 
-    await execManager.executeCommand(command, options)
+    await execManager.executeCommand(rawCommand, options)
   }
 
   // 确定环境
@@ -977,17 +911,14 @@ class DxCli {
     return envManager.detectEnvironment(this.flags)
   }
 
-  // 规范化环境键到命令配置使用的命名（dev/prod/test/e2e）
+  // 规范化环境键到命令配置使用的命名（development/staging/production/test/e2e）
   normalizeEnvKey(env) {
     switch (String(env || '').toLowerCase()) {
       case 'development':
-      case 'dev':
-        return 'dev'
+        return 'development'
       case 'production':
-      case 'prod':
-        return 'prod'
+        return 'production'
       case 'staging':
-      case 'stage':
         return 'staging'
       case 'test':
         return 'test'
@@ -996,6 +927,23 @@ class DxCli {
       default:
         return env
     }
+  }
+
+  createExecutionFlags(environment) {
+    const envKey = this.normalizeEnvKey(environment)
+    const execFlags = { ...this.flags }
+
+    ;['dev', 'prod', 'staging', 'test', 'e2e'].forEach(key => {
+      delete execFlags[key]
+    })
+
+    if (envKey === 'production') execFlags.prod = true
+    else if (envKey === 'development') execFlags.dev = true
+    else if (envKey === 'test') execFlags.test = true
+    else if (envKey === 'e2e') execFlags.e2e = true
+    else if (envKey === 'staging') execFlags.staging = true
+
+    return execFlags
   }
 
 }

--- a/lib/cli/flags.js
+++ b/lib/cli/flags.js
@@ -1,11 +1,8 @@
 export const FLAG_DEFINITIONS = {
   _global: [
     { flag: '--dev' },
-    { flag: '--development' },
     { flag: '--prod' },
-    { flag: '--production' },
     { flag: '--staging' },
-    { flag: '--stage' },
     { flag: '--test' },
     { flag: '--e2e' },
     { flag: '--no-env-check' },
@@ -59,15 +56,12 @@ export function parseFlags(args = []) {
     if (!flag.startsWith('-')) continue
     switch (flag) {
       case '--dev':
-      case '--development':
         flags.dev = true
         break
       case '--prod':
-      case '--production':
         flags.prod = true
         break
       case '--staging':
-      case '--stage':
         flags.staging = true
         break
       case '--test':

--- a/lib/cli/help-model.js
+++ b/lib/cli/help-model.js
@@ -1,0 +1,217 @@
+const ENVIRONMENT_KEYS = new Set(['development', 'production', 'staging', 'test', 'e2e'])
+const COMMAND_LIST_HIDDEN = new Set(['help'])
+const META_KEYS = new Set(['help', 'description', 'args', 'interactive', 'dangerous'])
+const INTERNAL_CONFIG_KEYS = new Set([
+  'services',
+  'urls',
+  'preflight',
+  'ecosystemConfig',
+  'pm2Bin',
+  'backendDeploy',
+  'artifactDeploy',
+  'telegramWebhook',
+])
+
+export function buildHelpRuntimeContext(cli = {}) {
+  return {
+    registeredCommands: getRegisteredCommands(cli),
+    knownFlags: getKnownFlags(cli),
+  }
+}
+
+export function getRegisteredCommands(cli = {}) {
+  const handlers = cli?.commandHandlers
+  if (!handlers || typeof handlers !== 'object') return []
+
+  return Object.keys(handlers).filter(name => !COMMAND_LIST_HIDDEN.has(name))
+}
+
+export function getKnownFlags(cli = {}) {
+  const definitions = cli?.flagDefinitions
+  const knownFlags = new Map()
+
+  if (!definitions || typeof definitions !== 'object') return knownFlags
+
+  for (const entries of Object.values(definitions)) {
+    if (!Array.isArray(entries)) continue
+    for (const entry of entries) {
+      if (!entry?.flag) continue
+      knownFlags.set(entry.flag, {
+        expectsValue: Boolean(entry.expectsValue),
+      })
+    }
+  }
+
+  return knownFlags
+}
+
+export function classifyCommandNode(node = {}) {
+  if (node?.help?.nodeType) return node.help.nodeType
+  if (looksLikeInternalConfigBag(node)) return 'internal-config-bag'
+  if (node?.command || node?.internal) return 'target-leaf'
+  if (node?.concurrent || node?.sequential) return 'orchestration-node'
+  if (looksLikeEnvContainer(node)) return 'env-container'
+  if (looksLikeCategoryNode(node)) return 'category-node'
+  return 'unknown-node'
+}
+
+export function isVisibleHelpNode(name, node, nodeType = classifyCommandNode(node)) {
+  void name
+
+  if (node?.help?.expose === false) return false
+  if (nodeType === 'internal-config-bag') return false
+  if (nodeType === 'category-node') return false
+  if (nodeType === 'orchestration-node') return node?.help?.expose === true
+  return true
+}
+
+export function getGlobalHelpModel(commands = {}, context = {}) {
+  const registeredCommands = Array.isArray(context?.registeredCommands)
+    ? context.registeredCommands
+    : []
+
+  return {
+    summary: commands?.help?.summary ?? '',
+    commands: registeredCommands.map(name => getCommandHelpModel(commands, name, context)),
+    globalOptions: normalizeArray(commands?.help?.globalOptions),
+    examples: normalizeArray(commands?.help?.examples),
+  }
+}
+
+export function getCommandHelpModel(commands = {}, commandName, context = {}) {
+  const commandConfig = commands?.[commandName] ?? {}
+  const commandHelp = getCommandHelpConfig(commands, commandName)
+
+  return {
+    name: commandName,
+    summary: resolveSummary(commandConfig, commandHelp),
+    usage: resolveUsage(commandName, commandHelp, commandConfig),
+    args: normalizeArray(commandHelp?.args),
+    notes: normalizeArray(commandHelp?.notes),
+    examples: normalizeArray(commandHelp?.examples),
+    options: normalizeArray(commandHelp?.options),
+    targets: resolveVisibleTargets(commands, commandName, commandConfig, context),
+  }
+}
+
+export function resolveSummary(node = {}, help = null) {
+  return help?.summary || node?.help?.summary || node?.description || ''
+}
+
+function resolveUsage(commandName, commandHelp = {}, commandConfig = {}) {
+  return commandHelp?.usage || generateUsage(commandName, commandConfig)
+}
+
+function generateUsage(commandName, commandConfig = {}) {
+  switch (commandName) {
+    case 'start':
+      return 'dx start <service> [环境标志]'
+    case 'build':
+    case 'package':
+      return `dx ${commandName} <target> [环境标志]`
+    case 'db':
+      return 'dx db <action> [name] [环境标志]'
+    case 'test':
+      return 'dx test [type] <target> [path]'
+    case 'deploy':
+    case 'clean':
+    case 'cache':
+      return `dx ${commandName} <target>`
+    case 'help':
+      return 'dx help [command]'
+    case 'worktree':
+      return 'dx worktree [action] [args...]'
+    case 'lint':
+    case 'status':
+      return `dx ${commandName}`
+    default:
+      return hasVisibleTargets(commandConfig) ? `dx ${commandName} <target>` : `dx ${commandName}`
+  }
+}
+
+function hasVisibleTargets(commandConfig) {
+  if (!isPlainObject(commandConfig)) return false
+
+  return Object.entries(commandConfig).some(([name, node]) => {
+    if (name === 'help') return false
+    return isVisibleHelpNode(name, node)
+  })
+}
+
+function resolveVisibleTargets(commands, commandName, commandConfig, context) {
+  void context
+
+  if (!isPlainObject(commandConfig)) return []
+
+  return Object.entries(commandConfig)
+    .filter(([name]) => name !== 'help')
+    .map(([name, node]) => {
+      const nodeType = classifyCommandNode(node)
+      if (!isVisibleHelpNode(name, node, nodeType)) return null
+
+      const targetHelp = getTargetHelpConfig(commands, commandName, name)
+
+      return {
+        name,
+        nodeType,
+        summary: resolveSummary(node, targetHelp),
+        notes: normalizeArray(targetHelp?.notes),
+        options: normalizeArray(targetHelp?.options),
+        examples: normalizeArray(targetHelp?.examples),
+      }
+    })
+    .filter(Boolean)
+}
+
+function getCommandHelpConfig(commands, commandName) {
+  const config = commands?.help?.commands?.[commandName]
+  return isPlainObject(config) ? config : {}
+}
+
+function getTargetHelpConfig(commands, commandName, targetName) {
+  const config = commands?.help?.targets?.[commandName]?.[targetName]
+  return isPlainObject(config) ? config : {}
+}
+
+function looksLikeInternalConfigBag(node) {
+  if (!isPlainObject(node)) return false
+  if (node.command || node.internal || node.concurrent || node.sequential) return false
+  if (looksLikeEnvContainer(node)) return false
+
+  const visibleKeys = getVisibleKeys(node)
+  if (visibleKeys.length === 0) return false
+
+  return visibleKeys.some(key => INTERNAL_CONFIG_KEYS.has(key))
+}
+
+function looksLikeEnvContainer(node) {
+  if (!isPlainObject(node)) return false
+  const visibleKeys = getVisibleKeys(node)
+  if (visibleKeys.length === 0) return false
+
+  const envKeys = visibleKeys.filter(key => ENVIRONMENT_KEYS.has(key))
+  return envKeys.length > 0 && envKeys.length === visibleKeys.length
+}
+
+function looksLikeCategoryNode(node) {
+  if (!isPlainObject(node)) return false
+  if (node.command || node.internal || node.concurrent || node.sequential) return false
+  if (looksLikeEnvContainer(node) || looksLikeInternalConfigBag(node)) return false
+
+  const visibleKeys = getVisibleKeys(node)
+  if (visibleKeys.length === 0) return false
+
+  return visibleKeys.every(key => isPlainObject(node[key]))
+}
+
+function getVisibleKeys(node) {
+  return Object.keys(node).filter(key => !META_KEYS.has(key))
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/lib/cli/help-renderer.js
+++ b/lib/cli/help-renderer.js
@@ -1,0 +1,135 @@
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function pushSection(lines, title, entries = []) {
+  const normalizedEntries = entries.filter(Boolean)
+  if (normalizedEntries.length === 0) return
+
+  lines.push('', title, ...normalizedEntries)
+}
+
+function formatExample(example = {}, indent = '  ') {
+  const command = typeof example.command === 'string' ? example.command : ''
+  const description = typeof example.description === 'string' ? example.description : ''
+
+  if (!command) return ''
+  if (!description) return `${indent}${command}`
+  return `${indent}${command}  # ${description}`
+}
+
+function formatOption(option = {}, indent = '  ') {
+  const flags = normalizeArray(option.flags).filter(Boolean).join(', ')
+  const description = typeof option.description === 'string' ? option.description : ''
+
+  if (!flags && !description) return ''
+  if (!description) return `${indent}${flags}`
+  return `${indent}${flags}  ${description}`
+}
+
+function getVisibleTargets(targets = []) {
+  return normalizeArray(targets).filter(target => target?.nodeType !== 'orchestration-node')
+}
+
+function formatTarget(target = {}, width = 0) {
+  const name = typeof target.name === 'string' ? target.name : ''
+  const summary = typeof target.summary === 'string' ? target.summary : ''
+  const lines = []
+
+  if (!name) return lines
+
+  lines.push(summary ? `  ${name.padEnd(width)}  ${summary}` : `  ${name}`)
+
+  normalizeArray(target.notes).forEach(note => {
+    if (!note) return
+    lines.push(`    提示: ${note}`)
+  })
+
+  normalizeArray(target.options).forEach(option => {
+    const rendered = formatOption(option, '    选项: ')
+    if (rendered) lines.push(rendered)
+  })
+
+  normalizeArray(target.examples).forEach(example => {
+    const rendered = formatExample(example, '    示例: ')
+    if (rendered) lines.push(rendered)
+  })
+
+  return lines
+}
+
+export function renderGlobalHelp(model = {}) {
+  const lines = []
+  const invocation = model.invocation || 'dx'
+  const title = [model.title, model.summary].filter(Boolean).join(' - ') || model.title || model.summary
+  const commands = normalizeArray(model.commands)
+  const commandWidth = Math.max(0, ...commands.map(command => String(command?.name || '').length))
+
+  if (title) {
+    lines.push('', title)
+  }
+
+  pushSection(lines, '用法:', [`  ${invocation} <命令> [选项] [参数...]`])
+  pushSection(
+    lines,
+    '命令:',
+    commands.map(command => {
+      const name = String(command?.name || '')
+      const summary = String(command?.summary || '')
+      if (!name) return ''
+      return summary ? `  ${name.padEnd(commandWidth)}  ${summary}` : `  ${name}`
+    }),
+  )
+  pushSection(lines, '选项:', normalizeArray(model.globalOptions).map(option => formatOption(option)))
+  pushSection(lines, '示例:', normalizeArray(model.examples).map(example => formatExample(example)))
+
+  return lines.join('\n')
+}
+
+export function renderCommandHelp(model = {}) {
+  const name = typeof model.name === 'string' ? model.name : ''
+  const usage = typeof model.usage === 'string' ? model.usage : ''
+  const args = normalizeArray(model.args)
+  const notes = normalizeArray(model.notes)
+  const options = normalizeArray(model.options)
+  const examples = normalizeArray(model.examples)
+  const targets = getVisibleTargets(model.targets)
+  const targetWidth = Math.max(0, ...targets.map(target => String(target?.name || '').length))
+  const lines = []
+
+  if (name) {
+    lines.push('', `${name} 命令用法:`)
+  }
+
+  if (usage) {
+    lines.push(`  ${usage}`)
+  }
+
+  if (model.summary) {
+    pushSection(lines, '摘要:', [`  ${model.summary}`])
+  }
+
+  pushSection(
+    lines,
+    '参数说明:',
+    args.map(arg => {
+      const argName = typeof arg.name === 'string' ? arg.name : ''
+      const description = typeof arg.description === 'string' ? arg.description : ''
+
+      if (!argName && !description) return ''
+      if (!description) return `  ${argName}`
+      return `  ${argName}: ${description}`
+    }),
+  )
+
+  pushSection(
+    lines,
+    '可用 target:',
+    targets.flatMap(target => formatTarget(target, targetWidth)),
+  )
+  pushSection(lines, '选项:', options.map(option => formatOption(option)))
+  pushSection(lines, '提示:', notes.map(note => (note ? `  ${note}` : '')))
+  pushSection(lines, '示例:', examples.map(example => formatExample(example)))
+
+  return lines.join('\n')
+}

--- a/lib/cli/help-schema.js
+++ b/lib/cli/help-schema.js
@@ -1,0 +1,549 @@
+import { logger } from '../logger.js'
+import { parseFlags } from './flags.js'
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function assertOptionalString(value, path) {
+  if (value === undefined) return
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${path} must be a non-empty string`)
+  }
+}
+
+function assertArrayOfObjects(value, path) {
+  if (value === undefined) return
+  if (!Array.isArray(value)) {
+    throw new Error(`${path} must be an array`)
+  }
+
+  value.forEach((entry, index) => {
+    if (!isPlainObject(entry)) {
+      throw new Error(`${path}[${index}] must be an object`)
+    }
+  })
+}
+
+function assertArray(value, path) {
+  if (value === undefined) return
+  if (!Array.isArray(value)) {
+    throw new Error(`${path} must be an array`)
+  }
+}
+
+function assertDescription(value, path) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${path} must include a description`)
+  }
+}
+
+function assertFlagsExist(flags, knownFlags, path) {
+  if (!Array.isArray(flags) || flags.length === 0) {
+    throw new Error(`${path} must include at least one flag`)
+  }
+
+  flags.forEach((flag, index) => {
+    if (typeof flag !== 'string' || flag.trim() === '') {
+      throw new Error(`${path}[${index}] must be a non-empty string`)
+    }
+    if (!knownFlags.has(flag)) {
+      throw new Error(`${path}[${index}] references unknown flag: ${flag}`)
+    }
+  })
+}
+
+function extractCommandName(command) {
+  if (typeof command !== 'string' || command.trim() === '') {
+    return ''
+  }
+
+  const tokens = command.trim().split(/\s+/)
+
+  if (tokens[0] === 'dx') {
+    return tokens[1] ?? ''
+  }
+
+  return tokens[0] ?? ''
+}
+
+function assertRegisteredCommand(command, registeredCommands, path) {
+  const commandName = extractCommandName(command)
+
+  if (!commandName) {
+    throw new Error(`${path} must include a command`)
+  }
+
+  if (!registeredCommands.has(commandName)) {
+    throw new Error(`${path} references unknown command: ${commandName}`)
+  }
+}
+
+function validateHelpExamples(examples, path, context) {
+  const { registeredCommands, exampleValidator } = context
+
+  assertArrayOfObjects(examples, path)
+
+  examples?.forEach((example, index) => {
+    const entryPath = `${path}[${index}]`
+    assertOptionalString(example.command, `${entryPath}.command`)
+    assertDescription(example.description, `${entryPath}.description`)
+    assertRegisteredCommand(example.command, registeredCommands, `${entryPath}.command`)
+
+    const result = exampleValidator(example.command)
+    if (!result?.ok) {
+      throw new Error(result?.reason || `${entryPath}.command failed validation`)
+    }
+  })
+}
+
+function validateHelpOptions(options, path, knownFlags) {
+  assertArrayOfObjects(options, path)
+
+  options?.forEach((option, index) => {
+    const entryPath = `${path}[${index}]`
+    assertFlagsExist(option.flags, knownFlags, `${entryPath}.flags`)
+    assertDescription(option.description, `${entryPath}.description`)
+  })
+}
+
+function validateCommandHelp(commandName, help, context) {
+  const { registeredCommands, usageValidator } = context
+
+  if (!isPlainObject(help)) {
+    throw new Error(`help.commands.${commandName} must be an object`)
+  }
+
+  if (!registeredCommands.has(commandName)) {
+    throw new Error(`help.commands.${commandName} references unknown command`)
+  }
+
+  assertOptionalString(help.summary, `help.commands.${commandName}.summary`)
+  assertArray(help.notes, `help.commands.${commandName}.notes`)
+
+  help.notes?.forEach((note, index) => {
+    assertOptionalString(note, `help.commands.${commandName}.notes[${index}]`)
+  })
+
+  validateHelpOptions(
+    help.options,
+    `help.commands.${commandName}.options`,
+    context.knownFlags,
+  )
+  validateHelpExamples(help.examples, `help.commands.${commandName}.examples`, context)
+
+  if (help.usage !== undefined) {
+    assertOptionalString(help.usage, `help.commands.${commandName}.usage`)
+    const result = usageValidator(commandName, help.usage)
+
+    if (!result?.ok) {
+      throw new Error(result?.reason || `help.commands.${commandName}.usage failed validation`)
+    }
+  }
+}
+
+function validateTargetHelp(commandName, targetName, help, commands, context) {
+  const entryPath = `help.targets.${commandName}.${targetName}`
+
+  if (!isPlainObject(help)) {
+    throw new Error(`${entryPath} must be an object`)
+  }
+
+  if (!context.registeredCommands.has(commandName) || !isPlainObject(commands?.[commandName])) {
+    throw new Error(`help.targets.${commandName} references unknown command`)
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(commands[commandName], targetName)) {
+    throw new Error(`${entryPath} references unknown target`)
+  }
+
+  assertOptionalString(help.summary, `${entryPath}.summary`)
+  assertArray(help.notes, `${entryPath}.notes`)
+
+  help.notes?.forEach((note, index) => {
+    assertOptionalString(note, `${entryPath}.notes[${index}]`)
+  })
+
+  validateHelpOptions(help.options, `${entryPath}.options`, context.knownFlags)
+  validateHelpExamples(help.examples, `${entryPath}.examples`, context)
+}
+
+export function validateHelpConfig(commands, context = {}) {
+  const {
+    registeredCommands = [],
+    knownFlags = new Map(),
+    usageValidator = () => ({ ok: true }),
+    exampleValidator = () => ({ ok: true }),
+  } = context
+
+  if (!isPlainObject(commands)) {
+    throw new Error('commands must be an object')
+  }
+
+  const normalizedContext = {
+    registeredCommands: new Set(registeredCommands),
+    knownFlags,
+    usageValidator,
+    exampleValidator,
+  }
+
+  const help = commands.help
+  if (help === undefined) {
+    return commands
+  }
+
+  if (!isPlainObject(help)) {
+    throw new Error('help must be an object')
+  }
+
+  assertOptionalString(help.summary, 'help.summary')
+  validateHelpOptions(help.globalOptions, 'help.globalOptions', normalizedContext.knownFlags)
+  validateHelpExamples(help.examples, 'help.examples', normalizedContext)
+
+  if (help.commands !== undefined) {
+    if (!isPlainObject(help.commands)) {
+      throw new Error('help.commands must be an object')
+    }
+
+    Object.entries(help.commands).forEach(([commandName, commandHelp]) => {
+      validateCommandHelp(commandName, commandHelp, normalizedContext)
+    })
+  }
+
+  if (help.targets !== undefined) {
+    if (!isPlainObject(help.targets)) {
+      throw new Error('help.targets must be an object')
+    }
+
+    Object.entries(help.targets).forEach(([commandName, targetHelp]) => {
+      if (!isPlainObject(targetHelp)) {
+        throw new Error(`help.targets.${commandName} must be an object`)
+      }
+
+      Object.entries(targetHelp).forEach(([targetName, targetEntryHelp]) => {
+        validateTargetHelp(commandName, targetName, targetEntryHelp, commands, normalizedContext)
+      })
+    })
+  }
+
+  return commands
+}
+
+export function buildStrictHelpValidationContext(cli) {
+  const knownFlags = new Map()
+  for (const definitions of Object.values(cli?.flagDefinitions || {})) {
+    if (!Array.isArray(definitions)) continue
+    for (const definition of definitions) {
+      if (!definition?.flag) continue
+      knownFlags.set(definition.flag, definition)
+    }
+  }
+
+  return {
+    registeredCommands: Object.keys(cli?.commandHandlers || {}),
+    knownFlags,
+    usageValidator: (commandName, usageText) =>
+      validateUsageAgainstRuntime(commandName, usageText, cli),
+    exampleValidator: commandText => validateExampleCommandAgainstCli(commandText, cli),
+  }
+}
+
+export function validateExampleCommandAgainstCli(commandText, cli) {
+  let tokens
+
+  try {
+    tokens = shellLikeSplit(commandText)
+  } catch (error) {
+    return { ok: false, reason: error.message }
+  }
+
+  if (tokens[0] !== cli.invocation) {
+    return { ok: false, reason: `example must start with ${cli.invocation}` }
+  }
+
+  const commandName = tokens[1]
+  if (!commandName) {
+    return { ok: false, reason: 'example must include a top-level command' }
+  }
+
+  if (!cli.commandHandlers?.[commandName]) {
+    return { ok: false, reason: `unknown command: ${commandName}` }
+  }
+
+  return runCliInputValidation(cli, tokens.slice(1))
+}
+
+export function validateUsageAgainstRuntime(commandName, usageText, cli) {
+  let tokens
+
+  try {
+    tokens = shellLikeSplit(usageText)
+  } catch (error) {
+    return { ok: false, reason: error.message }
+  }
+
+  if (tokens[0] !== cli.invocation) {
+    return { ok: false, reason: `usage must start with ${cli.invocation}` }
+  }
+
+  if (tokens[1] !== commandName) {
+    return {
+      ok: false,
+      reason: `usage for ${commandName} must start with "${cli.invocation} ${commandName}"`,
+    }
+  }
+
+  const placeholderTokens = tokens
+    .slice(2)
+    .filter(token => isPlaceholderToken(token) && !isEnvironmentPlaceholder(token))
+  const runtimeMaxPositionals = getRuntimeMaxPositionals(commandName)
+
+  if (
+    Number.isInteger(runtimeMaxPositionals) &&
+    placeholderTokens.length > runtimeMaxPositionals
+  ) {
+    return {
+      ok: false,
+      reason: `usage for ${commandName} advertises ${placeholderTokens.length} positionals but runtime allows ${runtimeMaxPositionals}`,
+    }
+  }
+
+  if (mentionsPositionalEnvironmentPlaceholder(tokens)) {
+    return {
+      ok: false,
+      reason: `usage for ${commandName} must use environment flags instead of positional env placeholders`,
+    }
+  }
+
+  if (commandName === 'start' && !tokens.includes('<service>')) {
+    return { ok: false, reason: 'usage for start must include <service>' }
+  }
+
+  return { ok: true }
+}
+
+function getRuntimeMaxPositionals(commandName) {
+  switch (commandName) {
+    case 'help':
+      return 1
+    case 'build':
+    case 'package':
+    case 'clean':
+    case 'cache':
+      return 1
+    case 'db':
+      return 2
+    case 'test':
+      return 3
+    case 'worktree':
+      return 3
+    case 'start':
+      return 1
+    case 'lint':
+    case 'status':
+      return 0
+    default:
+      return null
+  }
+}
+
+function runCliInputValidation(cli, args) {
+  if (typeof cli?.validateInputs !== 'function') {
+    return validateArgumentTokens(args, cli)
+  }
+
+  const exitSpy = process.exit
+  const originalLogger = {
+    error: logger.error,
+    info: logger.info,
+  }
+  const messages = []
+  const originalState = {
+    args: cli.args,
+    command: cli.command,
+    flags: cli.flags,
+    subcommand: cli.subcommand,
+  }
+
+  try {
+    process.exit = code => {
+      throw new Error(`process.exit:${code}`)
+    }
+    logger.error = message => {
+      messages.push(String(message))
+    }
+    logger.info = message => {
+      messages.push(String(message))
+    }
+
+    cli.args = [...args]
+    cli.flags = parseFlags(cli.args)
+    cli.command = cli.args[0]
+    cli.subcommand = cli.args[1]
+    cli.validateInputs()
+    return { ok: true }
+  } catch (error) {
+    if (String(error?.message || '').startsWith('process.exit:')) {
+      return { ok: false, reason: messages.join(' | ') || error.message }
+    }
+    throw error
+  } finally {
+    process.exit = exitSpy
+    logger.error = originalLogger.error
+    logger.info = originalLogger.info
+    cli.args = originalState.args
+    cli.command = originalState.command
+    cli.flags = originalState.flags
+    cli.subcommand = originalState.subcommand
+  }
+}
+
+function validateArgumentTokens(args, cli) {
+  const tokens = Array.isArray(args) ? [...args] : []
+  const commandName = tokens[0]
+  if (!commandName) {
+    return { ok: false, reason: 'example must include a top-level command' }
+  }
+
+  const definitions = cli?.flagDefinitions || {}
+  const knownFlags = new Map()
+  for (const entries of Object.values(definitions)) {
+    if (!Array.isArray(entries)) continue
+    for (const entry of entries) {
+      if (!entry?.flag) continue
+      knownFlags.set(entry.flag, Boolean(entry.expectsValue))
+    }
+  }
+
+  const positionalArgs = []
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    if (token === '--') break
+    if (!token.startsWith('-')) {
+      positionalArgs.push(token)
+      continue
+    }
+
+    if (!knownFlags.has(token)) {
+      return { ok: false, reason: `检测到未识别的选项: ${token}` }
+    }
+
+    if (knownFlags.get(token)) {
+      const next = tokens[index + 1]
+      if (next === undefined || next.startsWith('-')) {
+        return { ok: false, reason: `选项 ${token} 需要提供参数值` }
+      }
+      index += 1
+    }
+  }
+
+  const maxByCommand = {
+    help: 1,
+    build: 1,
+    package: 1,
+    db: 2,
+    test: 3,
+    worktree: 3,
+    start: 1,
+    lint: 0,
+    clean: 1,
+    cache: 1,
+    status: 0,
+  }
+
+  const max = maxByCommand[commandName]
+  if (Number.isInteger(max) && positionalArgs.length > max) {
+    return { ok: false, reason: `命令 ${commandName} 存在未识别的额外参数: ${positionalArgs.slice(max).join(', ')}` }
+  }
+
+  return { ok: true }
+}
+
+function isPlaceholderToken(token) {
+  return (
+    (token.startsWith('<') && token.endsWith('>')) ||
+    (token.startsWith('[') && token.endsWith(']'))
+  )
+}
+
+function isEnvironmentPlaceholder(token) {
+  return token === '[环境标志]'
+}
+
+function mentionsPositionalEnvironmentPlaceholder(tokens) {
+  return tokens.some(token => {
+    const normalized = token.replace(/^[<[|]+|[\]>|]+$/g, '').toLowerCase()
+    return normalized === 'env' || normalized === 'environment'
+  })
+}
+
+export function shellLikeSplit(text) {
+  const tokens = []
+  let current = ''
+  let quote = null
+  let tokenStarted = false
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index]
+
+    if (quote) {
+      if (character === '\\') {
+        const next = text[index + 1]
+        if (next === quote || next === '\\') {
+          current += next
+          tokenStarted = true
+          index += 1
+          continue
+        }
+      }
+
+      if (character === quote) {
+        quote = null
+        continue
+      }
+
+      current += character
+      tokenStarted = true
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+      tokenStarted = true
+      continue
+    }
+
+    if (character === '\\') {
+      const next = text[index + 1]
+      if (next !== undefined) {
+        current += next
+        tokenStarted = true
+        index += 1
+        continue
+      }
+    }
+
+    if (/\s/.test(character)) {
+      if (tokenStarted) {
+        tokens.push(current)
+        current = ''
+        tokenStarted = false
+      }
+      continue
+    }
+
+    current += character
+    tokenStarted = true
+  }
+
+  if (quote) {
+    const quoteName = quote === '"' ? 'double' : 'single'
+    throw new Error(`Unclosed ${quoteName} quote in "${text}"`)
+  }
+
+  if (tokenStarted) {
+    tokens.push(current)
+  }
+
+  return tokens
+}

--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -1,319 +1,141 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { buildHelpRuntimeContext, getCommandHelpModel, getGlobalHelpModel } from './help-model.js'
+import { FLAG_DEFINITIONS } from './flags.js'
+import { renderCommandHelp, renderGlobalHelp } from './help-renderer.js'
+import { buildStrictHelpValidationContext, validateHelpConfig } from './help-schema.js'
 import { getPackageVersion } from '../version.js'
 
-export function showHelp() {
-  const version = getPackageVersion()
-  const lines = [
-    '',
-    `DX CLI v${version} - 统一开发环境管理工具`,
-    '',
-    '用法:',
-    '  dx <命令> [选项] [参数...]',
-    '',
-    '命令:',
-    '  start [service] [环境标志]  启动/桥接服务',
-    '    service: 由 dx/config/commands.json 的 start.* 决定（默认: dev）',
-    '    stack: 需在 commands.json 配置 start.stack（internal: pm2-stack）',
-    '    环境标志: --dev, --staging, --prod, --test, --e2e（支持别名 --development、--production 等）',
-    "    说明: 传入 --staging 时会加载 '.env.staging(.local)' 层，同时复用生产构建/启动流程",
-    '',
-    '  build [target] [环境标志]   构建应用',
-    '    target: backend, shared, front, admin, mobile, all, sdk, affected (默认: all)',
-    '    环境标志: --dev, --staging, --prod, --test, --e2e（未指定时默认 --dev）',
-    '',
-    '  deploy <target> [环境标志]  部署前端到 Vercel 或后端制品到远端主机',
-    '    target: front, admin, merchant, telegram-bot, all, backend',
-    '    环境标志: --dev, --staging, --prod（默认: Vercel 目标为 --staging；backend 制品发布目标默认 --dev）',
-    '',
-    '  install                  安装依赖（使用 frozen-lockfile 确保版本一致）',
-    '',
-    '  package backend [环境标志]  构建后端部署包（生成 backend-<version>-<sha>.tar.gz）',
-    '    环境标志: --dev, --staging, --prod, --test, --e2e（默认 --dev）',
-    '    产物位置: dist/backend/backend-*.tar.gz',
-    '    内含: dist/、node_modules(生产依赖)、prisma/、config/.env.runtime、bin/start.sh',
-    '',
-    '  db [action] [环境标志]      数据库操作',
-    '    action: generate, migrate, deploy, reset, seed, format, script',
-    '    用法示例:',
-    '      dx db migrate --dev --name add_user_table   # 创建新的迁移（开发环境需指定名称）',
-    '      dx db deploy --dev                          # 应用开发环境已有迁移',
-    '      dx db deploy --prod                         # 生产环境迁移（复用 deploy 流程，需确认）',
-    '      dx db script fix-email-verified-status --dev  # 运行数据库脚本（开发环境）',
-    '      dx db script fix-pending-transfer-status --prod  # 运行数据库脚本（生产环境，需确认）',
-    '      dx db script my-script --dev -- --arg1 --arg2  # 向脚本传递额外参数（-- 后面的部分）',
-    '',
-    '  test [type] [target] [path] [-t pattern|--name pattern]  运行测试',
-    '    type: e2e, unit (默认: e2e)',
-    '    target: 由 commands.json 的 test.<type>.<target> 决定（e2e 默认会拒绝隐式 all）',
-    '    path: 测试文件或目录路径 (guarded e2e target 必填，例如 backend/quantify)',
-    '    -t pattern / --name pattern: 指定测试用例名称模式 (可选，需要和 path 一起使用)',
-    '    说明: guarded E2E target 禁止无路径或 all 全量执行，dx test e2e all 也不受支持',
-    '',
-    '  worktree [action] [num...] Git Worktree管理',
-    '    action: make, del, list, clean',
-    '    num: issue编号 (make时需要1个，del时支持多个)',
-    '    支持批量删除: dx worktree del 123 456 789',
-    '    支持非交互式: dx worktree del 123 -Y',
-    '  注意：该封装与原生 git worktree 行为不同，勿混用',
-    '',
-    '  lint                   运行代码检查',
-    '',
-    '  contracts [generate]       导出后端 OpenAPI 并生成 Zod 合约（packages/api-contracts）',
-    '',
-    '  release version <semver>   统一同步 backend/front/admin-front 的版本号',
-    '',
-    '  clean [target]         清理操作',
-    '    target: all, deps (默认: all)',
-    '',
-    '  cache [action]         缓存清理',
-    '    action: clear (默认: clear)',
-    '',
-    '  status                 查看系统状态',
-    '',
-    '  initial                同步根目录 skills 到 ~/.codex/skills 和 ~/.claude/skills（覆盖同名文件）',
-    '',
-    '选项:',
-    ' --dev, --development   使用开发环境',
-    ' --prod, --production   使用生产环境',
-    '  --staging, --stage    使用预发环境（加载 .env.staging*.，复用生产流程）',
-    '  --test                 使用测试环境',
-    '  --e2e                  使用E2E测试环境',
-    '  -Y, --yes              跳过所有确认提示',
-    '   -v, --verbose          详细输出',
-    '   -h, --help             显示此帮助信息',
-    '  -V, --version          显示版本号',
-    '',
-    '示例:',
-    '  dx start stack            # PM2 交互式服务栈（需在 commands.json 配置 start.stack）',
-    '  dx start backend --dev    # 启动后端开发服务',
-    '  dx start front --dev      # 启动用户前端开发服务',
-    '  dx start admin --dev      # 启动管理后台开发服务',
-    '  dx start all              # 同时启动所有开发服务（默认 --dev）',
-    '  dx build all --prod       # 构建所有应用(生产环境)',
-    '  dx db deploy --dev       # 应用开发环境数据库迁移',
-    '  dx db reset --prod -Y     # 重置生产数据库(跳过确认)',
-    '  dx test e2e backend apps/backend/e2e/auth     # 按目录运行后端 E2E',
-    '  dx test e2e backend apps/backend/e2e/activity/activity.admin.e2e-spec.ts  # 运行单个E2E测试文件',
-    '  dx test e2e backend apps/backend/e2e/activity/activity.admin.e2e-spec.ts -t "should list all activity definitions"  # 运行特定测试用例',
-    '  dx test unit backend apps/backend/src/modules/chat/chat.service.spec.ts --name "should create chat"  # 运行单测中的特定用例',
-    '  dx test e2e quantify apps/quantify/e2e/health/health.e2e-spec.ts  # 运行 Quantify E2E 文件',
-    '  dx test unit backend apps/backend/src/modules/chat/chat.service.spec.ts  # 运行单个后端单测文件',
-    '  dx test e2e all          # 不受支持，必须指定 target 和 path',
-    '  dx deploy front --staging # 部署前端到 Vercel（staging）',
-    '  dx deploy backend --prod  # 构建 backend 制品并上传/部署到远端主机',
-    '  dx deploy backend --build-only # 仅构建 backend 制品，不执行远端部署',
-    '  dx worktree make 88       # 为issue #88创建worktree',
-    '  dx worktree del 88        # 删除issue #88的worktree',
-    '  dx worktree del 88 89 90 -Y  # 批量删除多个worktree（非交互式）',
-    '  dx worktree list          # 列出所有worktree',
-    '  dx clean deps             # 清理并重新安装依赖',
-    '  dx cache clear            # 清除 Nx 与依赖缓存',
-    '  dx contracts              # 导出 OpenAPI 并生成 Zod 合约',
-    '  dx release version 1.2.3  # 同步 backend/front/admin-front 版本号',
-    '',
-    '  # Stagewise 桥接（固定端口，自动清理占用）',
-    '  dx start stagewise-front      # 桥接 front: 3001 -> 3002（工作目录 apps/front）',
-    '  dx start stagewise-admin      # 桥接 admin-front: 3500 -> 3501（工作目录 apps/admin-front）',
-    '',
-    '  # Start 用法示例',
-    '  dx start backend --prod       # 以生产环境变量启动后端',
-    '  dx start backend --dev        # 以开发环境变量启动后端',
-    '  dx start backend --e2e        # 以 E2E 环境变量启动后端',
-    '',
-    '',
-  ]
+const HIDDEN_COMMANDS = new Set(['help'])
 
-  console.log(lines.join('\n'))
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
-export function showCommandHelp(command) {
-  const name = String(command || '').toLowerCase()
+function loadDefaultCommands() {
+  const configDir = process.env.DX_CONFIG_DIR || join(process.cwd(), 'dx', 'config')
+  const commandsPath = join(configDir, 'commands.json')
 
-  switch (name) {
-    case 'build':
-      console.log(`
-build 命令用法:
-  dx build <target> [环境标志]
-
-参数说明:
-  target: backend, front, admin, shared, mobile, sdk, all, affected
-  环境标志: --dev、--staging、--prod、--test、--e2e（默认 --dev）
-
-限制说明:
-  显式传入环境标志时，必须是该 target 实际支持的环境；不支持时会直接报错
-
-常见示例:
-  dx build backend --staging    # 使用 staging 环境变量构建后端 (prod 流程)
-  dx build front --prod         # 强制以生产配置构建前端
-  dx build mobile --staging     # 构建移动端 APK (staging 环境)
-  dx build mobile --prod        # 构建移动端 APK (生产环境)
-  dx build affected --dev       # 针对受影响项目执行开发态构建
-
-提示: 可通过 dx build <target> 分别构建受影响应用。
-`)
-      return
-
-    case 'db':
-      console.log(`
-db 命令用法:
-  dx db <action> [options]
-
-可选 action:
-  generate | migrate | deploy | reset | seed | format | script
-
-环境说明:
-  通过 --dev、--staging、--prod、--test、--e2e 指定 APP_ENV（默认 --dev）
-  --staging 会加载 .env.staging*. 文件，并复用 prod 的 Prisma / Nx 流程
-
-附加参数:
-  --name/-n <migration-name>    # 开发环境执行 migrate 必填，禁止通过位置参数传递
-
-帮助提示:
-  - 未提供迁移名称时命令会直接报错退出，避免 Prisma 进入交互式输入
-  - 仅允许在开发环境使用 \`dx db migrate --dev --name <migration-name>\` 创建迁移
-  - 非开发环境请使用 dx db deploy
-  - 使用模式示例: dx db migrate --dev --name init-user-table
-  - 如需仅执行已有迁移（本地/CI/生产），请使用 dx db deploy（无需 --name）
-
-script 子命令:
-  dx db script <script-name> [环境标志] [-- <脚本参数>...]
-  运行位于 apps/backend/prisma/scripts/ 目录下的数据库脚本
-
-  脚本参数说明:
-    使用 -- 分隔符后可传递任意参数给目标脚本
-    例如: dx db script my-script --dev -- --skip-cleanup --note="test"
-
-示例:
-  dx db migrate --dev --name init-user-table     # 创建新迁移（开发环境）
-  dx db deploy --dev                             # 应用开发环境已有迁移
-  dx db deploy --staging                         # 复用生产命令，加载 staging 环境变量
-  dx db reset --prod -Y                          # 生产环境重置 (需确认)
-  dx db script fix-email-verified-status --dev   # 运行数据库脚本（开发环境）
-  dx db script fix-pending-transfer-status --prod -Y  # 运行数据库脚本（生产环境，跳过确认）
-  dx db script guest-cleanup-verification --dev -- --help  # 查看脚本帮助
-  dx db script guest-cleanup-verification --dev -- --skip-cleanup --note="dry run"  # 传递脚本参数
-`)
-      return
-
-    case 'deploy':
-      console.log(`
-  deploy 命令用法:
-  dx deploy <target> [环境标志] [选项]
-
-  参数说明:
-  target: front, admin, merchant, telegram-bot, all, backend
-  环境标志:
-    - Vercel 目标默认 --staging
-    - backend 制品发布目标默认 --dev
-
-  backend 制品发布（target=backend）:
-    --build-only               仅本地构建并打包制品，不上传不远端部署
-    --skip-migration           远端部署时跳过 prisma migrate deploy
-
-  Telegram Webhook（仅 target=telegram-bot 生效）:
-    --webhook-path <path>       对外 webhook 路径（默认 /api/webhook）
-    --webhook-dry-run           只打印将设置的 URL，不调用 Telegram API
-    --strict-webhook            显式开启严格校验（默认已严格）
-    --no-strict-webhook         关闭严格校验（仅告警）
-
-  常见示例:
-  dx deploy front --staging           # 部署用户前端（staging）
-  dx deploy admin --prod              # 部署管理后台（生产）
-  dx deploy merchant --staging        # 部署商家前端（staging）
-  dx deploy telegram-bot --staging    # 部署 Telegram Bot + 自动配置 Webhook
-  dx deploy telegram-bot --staging --webhook-path /webhook    # 使用短路径（rewrite 到 /api/webhook）
-  dx deploy telegram-bot --prod --webhook-dry-run             # 仅打印，不实际调用 Telegram
-  dx deploy telegram-bot --dev --no-strict-webhook            # 开发环境显式降级为仅告警
-  dx deploy all --staging             # 串行部署 front + admin + merchant
-  dx deploy backend --prod            # 构建 backend 制品并部署到远端主机
-  dx deploy backend --build-only      # 仅构建 backend 制品
-`)
-      return
-
-    case 'start':
-      console.log(`
-start 命令用法:
-  dx start <service> [环境标志]
-
-服务说明:
-  service: backend, dev, stagewise-front, stagewise-admin
-
-环境说明:
-  支持 --dev、--staging、--prod、--test、--e2e。--staging 会注入 .env.staging*. 层并复用 prod 启动流程
-
-限制说明:
-  未指定 service 时默认使用 dev 套件，仅允许 --dev
-  stagewise 等单层 start 目标默认视为开发态目标，仅允许 --dev
-
-常见示例:
-  dx start backend --staging    # 使用 staging 配置启动后端 (生产模式流程)
-  dx start stagewise-front      # Stagewise 桥接用户前端，端口 3001 -> 3002
-
-提示: service 省略时默认启动 dev 套件，可结合 --dev/--staging/--prod 标志使用。
-`)
-      return
-
-    case 'test':
-      console.log(`
-test 命令用法:
-  dx test [type] [target] [path] [-t pattern|--name pattern]
-
-参数说明:
-  type: e2e, unit (默认: e2e)
-  target: 由 commands.json 的 test.<type>.<target> 决定
-  path: guarded e2e target 必须提供文件或目录路径
-  -t pattern / --name pattern: 指定测试用例名称模式，需要和 path 一起使用
-
-限制说明:
-  guarded E2E target 禁止无路径全量执行。
-  guarded E2E target 也不支持把 path 写成 all。
-  dx test e2e all 不受支持，必须显式指定 target 和 path。
-
-常见示例:
-  dx test e2e backend apps/backend/e2e/auth
-  dx test e2e backend apps/backend/e2e/auth/auth.login.e2e-spec.ts
-  dx test e2e backend apps/backend/e2e/auth/auth.login.e2e-spec.ts -t "should login"
-  dx test e2e quantify apps/quantify/e2e/health/health.e2e-spec.ts
-  dx test unit front
-  dx test unit admin
-`)
-      return
-
-    case 'contracts':
-      console.log(`
-contracts 命令用法:
-  dx contracts [generate|pull]
-
-说明:
-  1) 先运行: npx nx run backend:swagger
-  2) 再运行: openapi-zod-client 生成 packages/api-contracts/src/generated/backend.ts
-
-环境变量:
-  OPENAPI_BASE_URL  默认: http://localhost:3000/api/v1
-
-示例:
-  dx contracts
-  OPENAPI_BASE_URL="https://api.example.com/api/v1" dx contracts
-`)
-      return
-
-    case 'release':
-      console.log(`
-release 命令用法:
-  dx release version <semver>
-
-说明:
-  同步更新以下 package.json 的 version 字段（存在则更新，不存在则跳过）：
-  - apps/backend/package.json
-  - apps/front/package.json
-  - apps/admin-front/package.json
-
-示例:
-  dx release version 1.2.3
-  dx release version 1.2.3-beta.1
-`)
-      return
-
-    default:
-      showHelp()
+  try {
+    return JSON.parse(readFileSync(commandsPath, 'utf8'))
+  } catch {
+    return null
   }
+}
+
+function deriveRegisteredCommands(commands = {}) {
+  const ordered = []
+  const seen = new Set()
+  const sources = [
+    Array.isArray(commands?.help?.commandOrder) ? commands.help.commandOrder : [],
+    Object.keys(commands?.help?.commands || {}),
+    Object.keys(commands).filter(name => !HIDDEN_COMMANDS.has(name) && name !== 'help'),
+  ]
+
+  for (const entries of sources) {
+    for (const name of entries) {
+      if (typeof name !== 'string' || !name || seen.has(name)) continue
+      seen.add(name)
+      ordered.push(name)
+    }
+  }
+
+  return ordered
+}
+
+function buildSyntheticCliContext(commands) {
+  const commandHandlers = Object.fromEntries(
+    deriveRegisteredCommands(commands).map(name => [name, () => {}]),
+  )
+
+  return {
+    invocation: 'dx',
+    commands,
+    commandHandlers,
+    flagDefinitions: FLAG_DEFINITIONS,
+  }
+}
+
+function resolveCliContext(cliContext = null) {
+  if (isPlainObject(cliContext?.commands)) {
+    const runtimeContext = buildHelpRuntimeContext(cliContext)
+    validateHelpConfig(cliContext.commands, buildStrictHelpValidationContext(cliContext))
+    return {
+      invocation: cliContext.invocation || 'dx',
+      commands: cliContext.commands,
+      runtimeContext,
+    }
+  }
+
+  const commands = loadDefaultCommands()
+  if (!commands) return null
+
+  const syntheticCli = buildSyntheticCliContext(commands)
+  const runtimeContext = buildHelpRuntimeContext(syntheticCli)
+  validateHelpConfig(commands, buildStrictHelpValidationContext(syntheticCli))
+
+  return {
+    invocation: syntheticCli.invocation,
+    commands,
+    runtimeContext,
+  }
+}
+
+function hasRenderableCommandModel(model = {}) {
+  return Boolean(
+    model?.usage ||
+      model?.summary ||
+      model?.targets?.length ||
+      model?.notes?.length ||
+      model?.examples?.length ||
+      model?.options?.length,
+  )
+}
+
+function renderDynamicGlobalHelp(cliContext = null) {
+  const resolved = resolveCliContext(cliContext)
+  const version = getPackageVersion()
+  if (!resolved) {
+    return renderGlobalHelp({
+      title: `DX CLI v${version}`,
+      invocation: 'dx',
+    })
+  }
+
+  const model = getGlobalHelpModel(resolved.commands, resolved.runtimeContext)
+
+  return renderGlobalHelp({
+    title: `DX CLI v${version}`,
+    invocation: resolved.invocation,
+    ...model,
+  })
+}
+
+function renderDynamicCommandHelp(commandName, cliContext = null) {
+  const resolved = resolveCliContext(cliContext)
+  if (!resolved) return ''
+
+  const model = getCommandHelpModel(resolved.commands, commandName, resolved.runtimeContext)
+  if (!hasRenderableCommandModel(model)) return ''
+
+  return renderCommandHelp({
+    invocation: resolved.invocation,
+    ...model,
+  })
+}
+
+export function showHelp(cliContext = null) {
+  console.log(renderDynamicGlobalHelp(cliContext))
+}
+
+export function showCommandHelp(command, cliContext = null) {
+  const commandName = String(command || '').toLowerCase()
+  const dynamicOutput = renderDynamicCommandHelp(commandName, cliContext)
+
+  if (dynamicOutput) {
+    console.log(dynamicOutput)
+    return
+  }
+
+  showHelp(cliContext)
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -21,7 +21,6 @@ export class EnvManager {
     // 注意：'e2e' 在 dotenv 层使用独立层（.env.e2e），但在 NODE_ENV 上归并为 'test'
     this.APP_TO_NODE_ENV = {
       local: 'development',
-      dev: 'development',
       development: 'development',
       staging: 'production',
       production: 'production',
@@ -51,8 +50,8 @@ export class EnvManager {
   mapAppEnvToLayerEnv(appEnv) {
     const env = String(appEnv || '').toLowerCase()
     if (env === 'e2e') return 'e2e'
-    if (env === 'staging' || env === 'stage') return 'staging'
-    if (env === 'production' || env === 'prod') return 'production'
+    if (env === 'staging') return 'staging'
+    if (env === 'production') return 'production'
     if (env === 'test') return 'test'
     return 'development'
   }
@@ -79,9 +78,9 @@ export class EnvManager {
 
   // 检测当前环境（用于选择 dotenv 层，如 .env.production/.env.e2e）
   detectEnvironment(flags = {}) {
-    if (flags.prod || flags.production) return 'production'
+    if (flags.prod) return 'production'
     if (flags.staging) return 'staging'
-    if (flags.dev || flags.development) return 'development'
+    if (flags.dev) return 'development'
     if (flags.test) return 'test'
     if (flags.e2e) return 'e2e'
 

--- a/lib/worktree.js
+++ b/lib/worktree.js
@@ -79,6 +79,7 @@ const shellEscape = value => {
 }
 
 const ensureTrailingSlash = value => (value.endsWith('/') ? value : `${value}/`)
+const ISSUE_NUMBER_PATTERN = /^\d+$/
 
 class WorktreeManager {
   constructor() {
@@ -218,8 +219,27 @@ class WorktreeManager {
     return path.join(this.baseDir, `${this.prefix}${issueNumber}`)
   }
 
+  isStrictIssueNumber(issueNumber) {
+    return typeof issueNumber === 'string' && ISSUE_NUMBER_PATTERN.test(issueNumber)
+  }
+
+  extractIssueNumberFromPath(worktreePath) {
+    const baseName = path.basename(worktreePath)
+    if (!baseName.startsWith(this.prefix)) {
+      return null
+    }
+
+    const issueNumber = baseName.slice(this.prefix.length)
+    return this.isStrictIssueNumber(issueNumber) ? issueNumber : null
+  }
+
   // 创建 worktree
   async make(issueNumber, options = {}) {
+    if (!this.isStrictIssueNumber(issueNumber)) {
+      logger.error('issue 编号必须为纯数字字符串')
+      return false
+    }
+
     const worktreePath = this.getWorktreePath(issueNumber)
     const branchName = `issue-${issueNumber}`
     const baseBranch = (options.baseBranch || 'main').trim()
@@ -567,13 +587,18 @@ class WorktreeManager {
 
   // 删除 worktree（支持批量删除）
   async del(issueNumbers, options = {}) {
-    // 兼容单个 issue 编号的旧接口
-    if (typeof issueNumbers === 'string' || typeof issueNumbers === 'number') {
-      issueNumbers = [issueNumbers]
+    if (!Array.isArray(issueNumbers)) {
+      logger.error('请提供 issue 编号数组')
+      return false
     }
 
-    if (!Array.isArray(issueNumbers) || issueNumbers.length === 0) {
-      logger.error('请提供有效的 issue 编号')
+    if (issueNumbers.length === 0) {
+      logger.error('请至少提供一个 issue 编号')
+      return false
+    }
+
+    if (issueNumbers.some(issueNumber => !this.isStrictIssueNumber(issueNumber))) {
+      logger.error('issue 编号必须为纯数字字符串')
       return false
     }
 
@@ -854,9 +879,9 @@ class WorktreeManager {
       const worktrees = this.parseWorktreeList(worktreeList)
 
       // 过滤出 issue 相关的 worktree
-      const issueWorktrees = worktrees.filter(wt => {
-        return wt.path.includes(this.prefix)
-      })
+      const issueWorktrees = worktrees
+        .map(wt => ({ ...wt, issueNumber: this.extractIssueNumberFromPath(wt.path) }))
+        .filter(wt => wt.issueNumber)
 
       if (issueWorktrees.length === 0) {
         logger.info('没有找到 issue 相关的 worktree')
@@ -870,10 +895,6 @@ class WorktreeManager {
       console.log('----\t----\t\t----\t\t\t----')
 
       for (const wt of issueWorktrees) {
-        // 提取 issue 编号
-        const match = wt.path.match(/ai_monorepo_issue_(\d+)/)
-        const issueNum = match ? match[1] : '?'
-
         // 检查状态
         let status = '正常'
         if (wt.locked) {
@@ -918,7 +939,7 @@ class WorktreeManager {
           status = '无法访问'
         }
 
-        console.log(`#${issueNum}\t${wt.branch || 'detached'}\t${wt.path}\t${status}`)
+        console.log(`#${wt.issueNumber}\t${wt.branch || 'detached'}\t${wt.path}\t${status}`)
       }
 
       // 显示统计
@@ -990,10 +1011,9 @@ class WorktreeManager {
           }
         }
 
-        // 兜底：基于路径识别（使用更严格的正则）
-        const pathMatch = path.basename(wt.path).match(/^ai_monorepo_issue_(\d+)$/)
-        if (pathMatch && pathMatch[1]) {
-          issueNumbers.push(pathMatch[1])
+        const issueNumber = this.extractIssueNumberFromPath(wt.path)
+        if (issueNumber) {
+          issueNumbers.push(issueNumber)
         }
       }
 

--- a/test/backend-artifact-deploy-routing.test.js
+++ b/test/backend-artifact-deploy-routing.test.js
@@ -21,7 +21,7 @@ jest.unstable_mockModule('../lib/env.js', () => ({
   },
 }))
 
-const { parseFlags } = await import('../lib/cli/flags.js')
+const { FLAG_DEFINITIONS, parseFlags } = await import('../lib/cli/flags.js')
 const { showCommandHelp, showHelp } = await import('../lib/cli/help.js')
 const { handleDeploy } = await import('../lib/cli/commands/deploy.js')
 const { runBackendArtifactDeploy } = await import('../lib/backend-artifact-deploy.js')
@@ -104,15 +104,78 @@ describe('backend artifact deploy routing', () => {
 
   test('deploy help documents backend artifact mode and different defaults', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const cli = {
+      invocation: 'dx',
+      commands: {
+        help: {
+          summary: '统一开发环境管理工具',
+          commands: {
+            deploy: {
+              summary: '部署前端到 Vercel 或后端制品到远端主机',
+              usage: 'dx deploy <target> [环境标志] [选项]',
+              notes: ['backend 制品发布目标默认 --dev'],
+              examples: [
+                {
+                  command: 'dx deploy backend --prod',
+                  description: '构建 backend 制品并部署到远端主机',
+                },
+              ],
+            },
+          },
+          targets: {
+            deploy: {
+              backend: {
+                summary: '构建并部署 backend 制品到远端主机',
+                options: [
+                  {
+                    flags: ['--build-only'],
+                    description: '仅本地构建并打包制品，不上传不远端部署',
+                  },
+                  {
+                    flags: ['--skip-migration'],
+                    description: '远端部署时跳过 prisma migrate deploy',
+                  },
+                ],
+                examples: [
+                  {
+                    command: 'dx deploy backend --build-only',
+                    description: '仅构建 backend 制品',
+                  },
+                ],
+              },
+            },
+          },
+          examples: [
+            {
+              command: 'dx deploy backend --build-only',
+              description: '仅构建 backend 制品',
+            },
+          ],
+        },
+        deploy: {
+          backend: {
+            internal: 'backend-artifact-deploy',
+          },
+          front: {
+            description: '部署 front 到 Vercel',
+          },
+        },
+      },
+      commandHandlers: {
+        deploy: () => {},
+      },
+      flagDefinitions: FLAG_DEFINITIONS,
+    }
 
-    showHelp()
-    showCommandHelp('deploy')
+    showHelp(cli)
+    showCommandHelp('deploy', cli)
 
     const output = logSpy.mock.calls.flat().join('\n')
+    expect(output).toContain('部署前端到 Vercel 或后端制品到远端主机')
     expect(output).toContain('dx deploy backend --prod')
     expect(output).toContain('--build-only')
     expect(output).toContain('--skip-migration')
-    expect(output).toContain('默认 --staging')
+    expect(output).toContain('构建并部署 backend 制品到远端主机')
     expect(output).toContain('backend 制品发布目标默认 --dev')
 
     logSpy.mockRestore()

--- a/test/bin-unknown-command-fast-fail.test.js
+++ b/test/bin-unknown-command-fast-fail.test.js
@@ -1,22 +1,45 @@
 import { describe, test, expect } from '@jest/globals'
 import { execFileSync } from 'node:child_process'
-import { resolve } from 'node:path'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 
 describe('dx unknown command fast-fail', () => {
   test('unknown command exits immediately without startup checks', () => {
     const binPath = resolve(process.cwd(), 'bin', 'dx.js')
+    const configDir = mkdtempSync(join(tmpdir(), 'dx-unknown-help-'))
+    writeFileSync(
+      join(configDir, 'commands.json'),
+      JSON.stringify(
+        {
+          help: {
+            summary: 'Scoped DX help',
+            commands: {
+              start: { summary: 'Start summary' },
+            },
+          },
+          start: {},
+          ghost: {},
+        },
+        null,
+        2,
+      ),
+    )
 
     let output = ''
     try {
-      execFileSync('node', [binPath, 'inital'], {
+      execFileSync('node', [binPath, '--config-dir', configDir, 'inital'], {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe'],
       })
     } catch (error) {
       output = `${error.stdout || ''}${error.stderr || ''}`
+    } finally {
+      rmSync(configDir, { recursive: true, force: true })
     }
 
     expect(output).toContain('未知命令: inital')
+    expect(output).toContain('Start summary')
     expect(output).not.toContain('检测到 Prisma Client 未生成')
     expect(output).not.toContain('环境变量验证失败')
   })

--- a/test/build-command-guard.test.js
+++ b/test/build-command-guard.test.js
@@ -32,14 +32,15 @@ describe('dx build command guard', () => {
 
     expect(result.code).not.toBe(0)
     expect(result.output).toContain('构建目标 backend 不支持 --test 环境')
-    expect(result.output).toContain('dx build backend --dev')
-    expect(result.output).toContain('dx build backend --prod')
+    expect(result.output).toContain('显式传入环境标志时，必须是该 target 实际支持的环境')
   })
 
   test('build help explains explicit env must be supported by target', () => {
     const result = runDx(['help', 'build'])
 
     expect(result.code).toBe(0)
-    expect(result.output).toContain('显式传入环境标志时，必须是该 target 实际支持的环境')
+    expect(result.output).toContain('build 命令用法:')
+    expect(result.output).toContain('dx build <target> [环境标志]')
+    expect(result.output).toContain('backend')
   })
 })

--- a/test/compatibility-purge-batch1.test.js
+++ b/test/compatibility-purge-batch1.test.js
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const logger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  step: jest.fn(),
+  warn: jest.fn(),
+}
+
+jest.unstable_mockModule('../lib/logger.js', () => ({
+  logger,
+}))
+
+const { DxCli } = await import('../lib/cli/dx-cli.js')
+const { handleStart } = await import('../lib/cli/commands/start.js')
+const { handleBuild } = await import('../lib/cli/commands/core.js')
+const { handleDatabase } = await import('../lib/cli/commands/db.js')
+const { handleExport } = await import('../lib/cli/commands/export.js')
+
+function createCli({ commands, flags = {}, executeCommand, args } = {}) {
+  return Object.assign(Object.create(DxCli.prototype), {
+    commands,
+    flags,
+    invocation: 'dx',
+    args: args || ['dx'],
+    executeCommand: executeCommand || jest.fn(),
+    handleConcurrentCommands: jest.fn(),
+    handleSequentialCommands: jest.fn(),
+  })
+}
+
+function runDx(args) {
+  const binPath = resolve(process.cwd(), 'bin', 'dx.js')
+
+  try {
+    return {
+      code: 0,
+      output: execFileSync('node', [binPath, ...args], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          AI_SKIP_ENV_CHECK: 'true',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+    }
+  } catch (error) {
+    return {
+      code: error.status ?? 1,
+      output: `${error.stdout || ''}${error.stderr || ''}`,
+    }
+  }
+}
+
+describe('compatibility purge batch 1', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.exitCode
+  })
+
+  test('dx dev is treated as an unknown command instead of a compatibility alias', () => {
+    const result = runDx(['dev', 'backend'])
+
+    expect(result.code).not.toBe(0)
+    expect(result.output).toContain('未知命令: dev')
+    expect(result.output).not.toContain('`dx dev` 命令已移除，统一使用 `dx start`。')
+  })
+
+  test('legacy environment flag aliases are rejected', () => {
+    const cases = ['--development', '--production', '--stage']
+
+    for (const flag of cases) {
+      const result = runDx(['start', 'backend', flag])
+
+      expect(result.code).not.toBe(0)
+      expect(result.output).toContain(`检测到未识别的选项: ${flag}`)
+    }
+  })
+
+  test('handleStart no longer falls back to legacy commands.dev entries', async () => {
+    const executeCommand = jest.fn()
+    const cli = createCli({
+      commands: {
+        start: {},
+        dev: {
+          backend: {
+            command: 'echo legacy backend',
+            ports: [3001],
+          },
+        },
+      },
+      flags: { dev: true },
+      executeCommand,
+    })
+
+    await handleStart(cli, ['backend'])
+
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith('未找到启动配置: backend')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('collectStartPorts only uses the selected start config ports', () => {
+    const cli = createCli({
+      commands: {
+        dev: {
+          backend: {
+            ports: [3999],
+          },
+        },
+      },
+    })
+
+    const envKey = cli.normalizeEnvKey('development')
+
+    expect(envKey).toBe('development')
+    expect(cli.collectStartPorts('backend', { ports: [3000] }, envKey)).toEqual([3000])
+  })
+
+  test('build uses strict full environment keys', async () => {
+    const executeCommand = jest.fn()
+    const cli = createCli({
+      commands: {
+        build: {
+          backend: {
+            production: {
+              command: 'echo build production',
+              app: 'backend',
+            },
+          },
+        },
+      },
+      flags: { prod: true },
+      executeCommand,
+    })
+
+    await handleBuild(cli, ['backend'])
+
+    expect(executeCommand).toHaveBeenCalledWith({
+      command: 'echo build production',
+      app: 'backend',
+    })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  test('build no longer falls back from staging to prod config', async () => {
+    const executeCommand = jest.fn()
+    const cli = createCli({
+      commands: {
+        build: {
+          backend: {
+            prod: {
+              command: 'echo legacy prod build',
+              app: 'backend',
+            },
+          },
+        },
+      },
+      flags: { staging: true },
+      executeCommand,
+    })
+
+    await handleBuild(cli, ['backend'])
+
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith('构建目标 backend 不支持 --staging 环境')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('db deploy uses strict full environment keys', async () => {
+    const executeCommand = jest.fn()
+    const cli = createCli({
+      commands: {
+        db: {
+          deploy: {
+            production: {
+              command: 'echo db deploy production',
+              app: 'backend',
+            },
+          },
+        },
+      },
+      flags: { prod: true },
+      executeCommand,
+      args: ['db', 'deploy', '--prod'],
+    })
+
+    await handleDatabase(cli, ['deploy'])
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      {
+        command: 'echo db deploy production',
+        app: 'backend',
+        env: { NX_CACHE: 'false' },
+      },
+      { prod: true },
+    )
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  test('db deploy no longer falls back from staging to prod config', async () => {
+    const executeCommand = jest.fn()
+    const cli = createCli({
+      commands: {
+        db: {
+          deploy: {
+            prod: {
+              command: 'echo legacy prod db deploy',
+              app: 'backend',
+            },
+          },
+        },
+      },
+      flags: { staging: true },
+      executeCommand,
+      args: ['db', 'deploy', '--staging'],
+    })
+
+    await handleDatabase(cli, ['deploy'])
+
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith('数据库操作 deploy 未提供 --staging 环境配置')
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('export uses strict full environment keys', async () => {
+    const executeCommand = jest.fn()
+    const cli = createCli({
+      commands: {
+        export: {
+          openapi: {
+            production: {
+              command: 'echo export production',
+              app: 'backend',
+            },
+          },
+        },
+      },
+      flags: { prod: true },
+      executeCommand,
+    })
+
+    await handleExport(cli, ['openapi'])
+
+    expect(executeCommand).toHaveBeenCalledWith({
+      command: 'echo export production',
+      app: 'backend',
+    })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  test('export no longer falls back from staging to prod config', async () => {
+    const executeCommand = jest.fn()
+    const cli = createCli({
+      commands: {
+        export: {
+          openapi: {
+            prod: {
+              command: 'echo legacy prod export',
+              app: 'backend',
+            },
+          },
+        },
+      },
+      flags: { staging: true },
+      executeCommand,
+    })
+
+    await handleExport(cli, ['openapi'])
+
+    expect(executeCommand).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith('导出目标 openapi 未提供 --staging 环境配置')
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/test/compatibility-purge-batch3.test.js
+++ b/test/compatibility-purge-batch3.test.js
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+
+const logger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  step: jest.fn(),
+  success: jest.fn(),
+  warn: jest.fn(),
+}
+
+const confirmManager = {
+  confirm: jest.fn(),
+}
+
+const execSync = jest.fn()
+
+const fsMock = {
+  cpSync: jest.fn(),
+  copyFileSync: jest.fn(),
+  existsSync: jest.fn(() => false),
+  lstatSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  rmSync: jest.fn(),
+  symlinkSync: jest.fn(),
+}
+
+jest.unstable_mockModule('../lib/logger.js', () => ({
+  logger,
+}))
+
+jest.unstable_mockModule('../lib/confirm.js', () => ({
+  confirmManager,
+}))
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync,
+}))
+
+jest.unstable_mockModule('node:fs', () => ({
+  default: fsMock,
+}))
+
+const worktreeManagerModule = await import('../lib/worktree.js')
+const worktreeManager = worktreeManagerModule.default
+const { handleWorktree } = await import('../lib/cli/commands/worktree.js')
+
+function createCli({ flags = {}, args = [], getWorktreeManager } = {}) {
+  return {
+    args,
+    flags,
+    getWorktreeManager: getWorktreeManager || jest.fn(async () => worktreeManager),
+  }
+}
+
+describe('compatibility purge batch 3', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    fsMock.existsSync.mockImplementation(() => false)
+    delete process.exitCode
+  })
+
+  test('handleWorktree rejects legacy action aliases instead of mapping them to strict commands', async () => {
+    const manager = {
+      clean: jest.fn(),
+      del: jest.fn(),
+      getAllIssueWorktrees: jest.fn(async () => []),
+      list: jest.fn(),
+      make: jest.fn(),
+    }
+
+    const cases = ['delete', 'rm', 'ls', 'prune']
+
+    for (const action of cases) {
+      const cli = createCli({
+        args: ['dx', 'worktree', action, '88'],
+        getWorktreeManager: jest.fn(async () => manager),
+      })
+
+      await handleWorktree(cli, [action, '88'])
+
+      expect(logger.error).toHaveBeenCalledWith(`未知的 worktree 操作: ${action}`)
+    }
+
+    expect(manager.del).not.toHaveBeenCalled()
+    expect(manager.list).not.toHaveBeenCalled()
+    expect(manager.clean).not.toHaveBeenCalled()
+  })
+
+  test('del rejects the legacy single-issue scalar interface', async () => {
+    const result = await worktreeManager.del('123')
+
+    expect(result).toBe(false)
+    expect(logger.error).toHaveBeenCalledWith('请提供 issue 编号数组')
+  })
+
+  test('del rejects guessed issue identifiers instead of accepting arbitrary values', async () => {
+    const result = await worktreeManager.del(['issue-123', 'abc'])
+
+    expect(result).toBe(false)
+    expect(logger.error).toHaveBeenCalledWith('issue 编号必须为纯数字字符串')
+  })
+
+  test('list displays issue numbers using the current repo prefix instead of the legacy hard-coded prefix', async () => {
+    execSync.mockReturnValueOnce(`worktree /tmp/dx_issue_42
+HEAD abcdef
+branch refs/heads/issue-42
+
+`)
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    let renderedRows = []
+
+    try {
+      await worktreeManager.list()
+      renderedRows = consoleSpy.mock.calls.map(call => call.join(' '))
+    } finally {
+      consoleSpy.mockRestore()
+    }
+
+    expect(renderedRows).toContainEqual(expect.stringContaining('#42\trefs/heads/issue-42\t/tmp/dx_issue_42'))
+  })
+
+  test('getAllIssueWorktrees no longer falls back to the legacy ai_monorepo path naming', async () => {
+    execSync.mockReturnValueOnce(`worktree /tmp/ai_monorepo_issue_99
+HEAD abcdef
+
+worktree /tmp/dx_issue_42
+HEAD 123456
+
+`)
+
+    await expect(worktreeManager.getAllIssueWorktrees()).resolves.toEqual(['42'])
+  })
+})

--- a/test/db-migrate-guard.test.js
+++ b/test/db-migrate-guard.test.js
@@ -39,7 +39,9 @@ describe('dx db migrate guard', () => {
     const result = runDx(['help', 'db'])
 
     expect(result.code).toBe(0)
-    expect(result.output).toContain('仅允许在开发环境使用 `dx db migrate --dev --name <migration-name>` 创建迁移')
-    expect(result.output).toContain('非开发环境请使用 dx db deploy')
+    expect(result.output).toContain('db 命令用法:')
+    expect(result.output).toContain('dx db <action> [name] [环境标志]')
+    expect(result.output).toContain('migrate')
+    expect(result.output).toContain('deploy')
   })
 })

--- a/test/dynamic-help-consistency.test.js
+++ b/test/dynamic-help-consistency.test.js
@@ -1,0 +1,610 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const logger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  step: jest.fn(),
+  success: jest.fn(),
+  warn: jest.fn(),
+}
+
+jest.unstable_mockModule('../lib/logger.js', () => ({
+  logger,
+}))
+
+const { DxCli } = await import('../lib/cli/dx-cli.js')
+const { parseFlags } = await import('../lib/cli/flags.js')
+const { validateHelpConfig } = await import('../lib/cli/help-schema.js')
+
+const CONFIG_FIXTURES = [
+  {
+    name: 'workspace config',
+    configDir: resolve(process.cwd(), 'dx', 'config'),
+    file: resolve(process.cwd(), 'dx', 'config', 'commands.json'),
+  },
+  {
+    name: 'example config',
+    configDir: resolve(process.cwd(), 'example', 'dx', 'config'),
+    file: resolve(process.cwd(), 'example', 'dx', 'config', 'commands.json'),
+  },
+]
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+function readCommands(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function createCli(configDir) {
+  const argvBackup = process.argv
+
+  try {
+    process.argv = ['node', 'dx']
+    return new DxCli({ configDir })
+  } finally {
+    process.argv = argvBackup
+  }
+}
+
+function buildRuntimeHelpContext(configDir) {
+  const cli = createCli(configDir)
+  const knownFlags = new Map()
+
+  for (const definitions of Object.values(cli.flagDefinitions)) {
+    for (const definition of definitions) {
+      knownFlags.set(definition.flag, definition)
+    }
+  }
+
+  return {
+    cli,
+    knownFlags,
+    registeredCommands: Object.keys(cli.commandHandlers),
+    exampleValidator: commandText => validateExampleCommand(commandText, cli),
+    usageValidator: (commandName, usageText) =>
+      validateUsageAgainstRuntime(commandName, usageText, cli),
+  }
+}
+
+function collectConfiguredExamples(commands) {
+  const examples = []
+
+  for (const [index, entry] of (commands.help?.examples || []).entries()) {
+    examples.push({
+      path: `help.examples[${index}]`,
+      command: entry.command,
+    })
+  }
+
+  for (const [commandName, commandHelp] of Object.entries(commands.help?.commands || {})) {
+    for (const [index, entry] of (commandHelp.examples || []).entries()) {
+      examples.push({
+        path: `help.commands.${commandName}.examples[${index}]`,
+        command: entry.command,
+      })
+    }
+  }
+
+  for (const [commandName, targets] of Object.entries(commands.help?.targets || {})) {
+    for (const [targetName, targetHelp] of Object.entries(targets || {})) {
+      for (const [index, entry] of (targetHelp.examples || []).entries()) {
+        examples.push({
+          path: `help.targets.${commandName}.${targetName}.examples[${index}]`,
+          command: entry.command,
+        })
+      }
+    }
+  }
+
+  return examples
+}
+
+function collectConfiguredOptions(commands) {
+  const options = []
+
+  for (const [index, entry] of (commands.help?.globalOptions || []).entries()) {
+    options.push({
+      path: `help.globalOptions[${index}]`,
+      flags: entry.flags || [],
+    })
+  }
+
+  for (const [commandName, commandHelp] of Object.entries(commands.help?.commands || {})) {
+    for (const [index, entry] of (commandHelp.options || []).entries()) {
+      options.push({
+        path: `help.commands.${commandName}.options[${index}]`,
+        flags: entry.flags || [],
+      })
+    }
+  }
+
+  for (const [commandName, targets] of Object.entries(commands.help?.targets || {})) {
+    for (const [targetName, targetHelp] of Object.entries(targets || {})) {
+      for (const [index, entry] of (targetHelp.options || []).entries()) {
+        options.push({
+          path: `help.targets.${commandName}.${targetName}.options[${index}]`,
+          flags: entry.flags || [],
+        })
+      }
+    }
+  }
+
+  return options
+}
+
+function collectConfiguredUsages(commands) {
+  const usages = []
+
+  for (const [commandName, commandHelp] of Object.entries(commands.help?.commands || {})) {
+    if (commandHelp.usage) {
+      usages.push({
+        path: `help.commands.${commandName}.usage`,
+        commandName,
+        usage: commandHelp.usage,
+      })
+    }
+  }
+
+  return usages
+}
+
+function validateExampleCommand(commandText, cli) {
+  let tokens
+
+  try {
+    tokens = shellLikeSplit(commandText)
+  } catch (error) {
+    return { ok: false, reason: error.message }
+  }
+
+  if (tokens[0] !== cli.invocation) {
+    return { ok: false, reason: `example must start with ${cli.invocation}` }
+  }
+
+  const commandName = tokens[1]
+  if (!commandName) {
+    return { ok: false, reason: 'example must include a top-level command' }
+  }
+
+  if (!cli.commandHandlers[commandName]) {
+    return { ok: false, reason: `unknown command: ${commandName}` }
+  }
+
+  return runCliInputValidation(cli, tokens.slice(1))
+}
+
+function validateUsageAgainstRuntime(commandName, usageText, cli) {
+  let tokens
+
+  try {
+    tokens = shellLikeSplit(usageText)
+  } catch (error) {
+    return { ok: false, reason: error.message }
+  }
+
+  if (tokens[0] !== cli.invocation) {
+    return { ok: false, reason: `usage must start with ${cli.invocation}` }
+  }
+
+  if (tokens[1] !== commandName) {
+    return {
+      ok: false,
+      reason: `usage for ${commandName} must start with "${cli.invocation} ${commandName}"`,
+    }
+  }
+
+  const placeholderTokens = tokens
+    .slice(2)
+    .filter(token => isPlaceholderToken(token) && !isEnvironmentPlaceholder(token))
+  const runtimeMaxPositionals = getRuntimeMaxPositionals(commandName, cli)
+
+  if (
+    Number.isInteger(runtimeMaxPositionals) &&
+    placeholderTokens.length > runtimeMaxPositionals
+  ) {
+    return {
+      ok: false,
+      reason: `usage for ${commandName} advertises ${placeholderTokens.length} positionals but runtime allows ${runtimeMaxPositionals}`,
+    }
+  }
+
+  if (mentionsPositionalEnvironmentPlaceholder(tokens)) {
+    return {
+      ok: false,
+      reason: `usage for ${commandName} must use environment flags instead of positional env placeholders`,
+    }
+  }
+
+  if (commandName === 'start') {
+    if (!tokens.includes('<service>')) {
+      return { ok: false, reason: 'usage for start must include <service>' }
+    }
+
+    if (supportsStartSubcommand(cli) && !tokens.some(token => token.includes('subcommand'))) {
+      return { ok: false, reason: 'usage for start omits supported stack subcommand' }
+    }
+  }
+
+  return { ok: true }
+}
+
+function getRuntimeMaxPositionals(commandName, cli) {
+  switch (commandName) {
+    case 'help':
+      return 1
+    case 'build':
+    case 'package':
+    case 'clean':
+    case 'cache':
+      return 1
+    case 'db':
+      return 2
+    case 'test':
+      return 3
+    case 'worktree':
+      return 3
+    case 'start':
+      return supportsStartSubcommand(cli) ? 2 : 1
+    case 'lint':
+    case 'status':
+      return 0
+    default:
+      return null
+  }
+}
+
+function supportsStartSubcommand(cli) {
+  return runCliPositionalValidation(cli, 'start', ['stack', 'front'], { dev: true }).ok
+}
+
+function runCliInputValidation(cli, args) {
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {
+    throw new Error(`process.exit:${code}`)
+  })
+  const originalState = {
+    args: cli.args,
+    command: cli.command,
+    flags: cli.flags,
+    subcommand: cli.subcommand,
+  }
+
+  try {
+    return withStableEnvironment(() => {
+      clearLoggerCalls()
+      cli.args = [...args]
+      cli.flags = parseFlags(cli.args)
+      cli.command = cli.args[0]
+      cli.subcommand = cli.args[1]
+      cli.validateInputs()
+      return { ok: true }
+    })
+  } catch (error) {
+    if (String(error?.message || '').startsWith('process.exit:')) {
+      return { ok: false, reason: formatLoggerReason(error.message) }
+    }
+    throw error
+  } finally {
+    cli.args = originalState.args
+    cli.command = originalState.command
+    cli.flags = originalState.flags
+    cli.subcommand = originalState.subcommand
+    exitSpy.mockRestore()
+  }
+}
+
+function runCliPositionalValidation(cli, commandName, positionalArgs, flags = {}) {
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {
+    throw new Error(`process.exit:${code}`)
+  })
+  const originalFlags = cli.flags
+
+  try {
+    return withStableEnvironment(() => {
+      clearLoggerCalls()
+      cli.flags = { ...flags }
+      cli.validatePositionalArgs(commandName, positionalArgs)
+      return { ok: true }
+    })
+  } catch (error) {
+    if (String(error?.message || '').startsWith('process.exit:')) {
+      return { ok: false, reason: formatLoggerReason(error.message) }
+    }
+    throw error
+  } finally {
+    cli.flags = originalFlags
+    exitSpy.mockRestore()
+  }
+}
+
+function clearLoggerCalls() {
+  Object.values(logger).forEach(mockFn => {
+    if (typeof mockFn.mockClear === 'function') {
+      mockFn.mockClear()
+    }
+  })
+}
+
+function formatLoggerReason(fallback) {
+  const messages = [...logger.error.mock.calls, ...logger.info.mock.calls]
+    .flat()
+    .filter(Boolean)
+    .map(message => String(message))
+
+  return messages.join(' | ') || fallback
+}
+
+function withStableEnvironment(callback) {
+  const previousAppEnv = process.env.APP_ENV
+  const previousNodeEnv = process.env.NODE_ENV
+
+  delete process.env.APP_ENV
+  process.env.NODE_ENV = 'development'
+
+  try {
+    return callback()
+  } finally {
+    if (previousAppEnv === undefined) {
+      delete process.env.APP_ENV
+    } else {
+      process.env.APP_ENV = previousAppEnv
+    }
+
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = previousNodeEnv
+    }
+  }
+}
+
+function isPlaceholderToken(token) {
+  return (
+    (token.startsWith('<') && token.endsWith('>')) ||
+    (token.startsWith('[') && token.endsWith(']'))
+  )
+}
+
+function isEnvironmentPlaceholder(token) {
+  return token === '[环境标志]'
+}
+
+function mentionsPositionalEnvironmentPlaceholder(tokens) {
+  return tokens.some(token => {
+    const normalized = token.replace(/^[<[|]+|[\]>|]+$/g, '').toLowerCase()
+    return normalized === 'env' || normalized === 'environment'
+  })
+}
+
+function shellLikeSplit(text) {
+  const tokens = []
+  let current = ''
+  let quote = null
+  let tokenStarted = false
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index]
+
+    if (quote) {
+      if (character === '\\') {
+        const next = text[index + 1]
+        if (next === quote || next === '\\') {
+          current += next
+          tokenStarted = true
+          index += 1
+          continue
+        }
+      }
+
+      if (character === quote) {
+        quote = null
+        continue
+      }
+
+      current += character
+      tokenStarted = true
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+      tokenStarted = true
+      continue
+    }
+
+    if (character === '\\') {
+      const next = text[index + 1]
+      if (next !== undefined) {
+        current += next
+        tokenStarted = true
+        index += 1
+        continue
+      }
+    }
+
+    if (/\s/.test(character)) {
+      if (tokenStarted) {
+        tokens.push(current)
+        current = ''
+        tokenStarted = false
+      }
+      continue
+    }
+
+    current += character
+    tokenStarted = true
+  }
+
+  if (quote) {
+    const quoteName = quote === '"' ? 'double' : 'single'
+    throw new Error(`Unclosed ${quoteName} quote in "${text}"`)
+  }
+
+  if (tokenStarted) {
+    tokens.push(current)
+  }
+
+  return tokens
+}
+
+describe('dynamic help example parser', () => {
+  test('keeps quoted arguments intact and preserves escaped quotes', () => {
+    expect(
+      shellLikeSplit(
+        'dx test e2e backend apps/backend/e2e/auth --test-name-pattern "auth \\"smoke\\" suite"',
+      ),
+    ).toEqual([
+      'dx',
+      'test',
+      'e2e',
+      'backend',
+      'apps/backend/e2e/auth',
+      '--test-name-pattern',
+      'auth "smoke" suite',
+    ])
+
+    expect(
+      shellLikeSplit(
+        "dx test e2e backend apps/backend/e2e/auth --name 'backend smoke suite'",
+      ),
+    ).toEqual([
+      'dx',
+      'test',
+      'e2e',
+      'backend',
+      'apps/backend/e2e/auth',
+      '--name',
+      'backend smoke suite',
+    ])
+  })
+
+  test('rejects unclosed quotes with a descriptive error', () => {
+    expect(() =>
+      shellLikeSplit('dx test e2e backend --test-name-pattern "auth smoke'),
+    ).toThrow('Unclosed double quote')
+  })
+})
+
+describe.each(CONFIG_FIXTURES)('$name dynamic help consistency', fixture => {
+  test('every configured example command stays valid against the live CLI parser', () => {
+    const commands = readCommands(fixture.file)
+    const { exampleValidator } = buildRuntimeHelpContext(fixture.configDir)
+    const failures = collectConfiguredExamples(commands)
+      .map(entry => {
+        const result = exampleValidator(entry.command)
+        return result.ok ? null : `${entry.path}: ${result.reason}`
+      })
+      .filter(Boolean)
+
+    expect(failures).toEqual([])
+  })
+
+  test('every configured option flag exists in FLAG_DEFINITIONS', () => {
+    const commands = readCommands(fixture.file)
+    const { knownFlags } = buildRuntimeHelpContext(fixture.configDir)
+    const failures = collectConfiguredOptions(commands)
+      .flatMap(entry =>
+        entry.flags.map(flag =>
+          knownFlags.has(flag) ? null : `${entry.path} references unknown flag: ${flag}`,
+        ),
+      )
+      .filter(Boolean)
+
+    expect(failures).toEqual([])
+  })
+
+  test('configured usage strings do not contradict positional validation', () => {
+    const commands = readCommands(fixture.file)
+    const { usageValidator } = buildRuntimeHelpContext(fixture.configDir)
+    const failures = collectConfiguredUsages(commands)
+      .map(entry => {
+        const result = usageValidator(entry.commandName, entry.usage)
+        return result.ok ? null : `${entry.path}: ${result.reason}`
+      })
+      .filter(Boolean)
+
+    expect(failures).toEqual([])
+  })
+})
+
+describe('dynamic help consistency with runtime callbacks', () => {
+  test('accepts quoted example arguments when validateHelpConfig uses the shell-like parser', () => {
+    const context = buildRuntimeHelpContext(resolve(process.cwd(), 'dx', 'config'))
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          test: readCommands(join(process.cwd(), 'dx', 'config', 'commands.json')).test,
+          help: {
+            commands: {
+              test: {
+                summary: 'Run tests',
+                examples: [
+                  {
+                    command:
+                      'dx test e2e backend apps/backend/e2e/auth --test-name-pattern "auth smoke"',
+                    description: 'Run a quoted test pattern',
+                  },
+                ],
+              },
+            },
+          },
+        },
+        context,
+      ),
+    ).not.toThrow()
+  })
+
+  test('rejects unclosed quoted examples before config drift reaches help output', () => {
+    const context = buildRuntimeHelpContext(resolve(process.cwd(), 'dx', 'config'))
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          test: readCommands(join(process.cwd(), 'dx', 'config', 'commands.json')).test,
+          help: {
+            commands: {
+              test: {
+                summary: 'Run tests',
+                examples: [
+                  {
+                    command:
+                      'dx test e2e backend apps/backend/e2e/auth --test-name-pattern "auth smoke',
+                    description: 'Broken quoted test pattern',
+                  },
+                ],
+              },
+            },
+          },
+        },
+        context,
+      ),
+    ).toThrow('Unclosed double quote')
+  })
+
+  test('rejects start usage that omits the supported stack subcommand', () => {
+    const commands = readCommands(join(process.cwd(), 'dx', 'config', 'commands.json'))
+    const context = buildRuntimeHelpContext(resolve(process.cwd(), 'dx', 'config'))
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          start: commands.start,
+          help: {
+            commands: {
+              start: {
+                summary: '启动/桥接服务',
+                usage: 'dx start <service> [环境标志]',
+              },
+            },
+          },
+        },
+        context,
+      ),
+    ).not.toThrow()
+  })
+})

--- a/test/dynamic-help-renderer.test.js
+++ b/test/dynamic-help-renderer.test.js
@@ -1,0 +1,414 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+async function loadHelpModel() {
+  return import('../lib/cli/help-model.js')
+}
+
+async function loadHelpRenderer() {
+  return import('../lib/cli/help-renderer.js')
+}
+
+async function loadHelpRuntime() {
+  return import('../lib/cli/help.js')
+}
+
+async function loadCoreCommands() {
+  return import('../lib/cli/commands/core.js')
+}
+
+async function loadDxCli() {
+  return import('../lib/cli/dx-cli.js')
+}
+
+function createTempConfig(commands) {
+  const configDir = mkdtempSync(join(tmpdir(), 'dx-help-config-'))
+  writeFileSync(join(configDir, 'commands.json'), JSON.stringify(commands, null, 2))
+  return configDir
+}
+
+const tempPaths = new Set()
+const originalDxConfigDir = process.env.DX_CONFIG_DIR
+
+afterEach(() => {
+  process.env.DX_CONFIG_DIR = originalDxConfigDir
+  for (const path of tempPaths) {
+    rmSync(path, { recursive: true, force: true })
+  }
+  tempPaths.clear()
+})
+
+describe('dynamic help model', () => {
+  test('global help uses registered commands instead of raw config roots', async () => {
+    const { getGlobalHelpModel } = await loadHelpModel()
+
+    const model = getGlobalHelpModel(
+      {
+        help: { summary: 'DX CLI summary' },
+        start: { help: { summary: 'Start services' } },
+        deploy: { help: { summary: 'Deploy apps' } },
+        development: { help: { summary: 'Development build' } },
+      },
+      {
+        registeredCommands: ['start', 'deploy'],
+      },
+    )
+
+    expect(model.commands.map(command => command.name)).toEqual(['start', 'deploy'])
+  })
+
+  test('help model hides internal config bags and category nodes from target list', async () => {
+    const { getCommandHelpModel } = await loadHelpModel()
+
+    const model = getCommandHelpModel(
+      {
+        start: {
+          stack: {
+            internal: 'pm2-stack',
+            description: 'PM2 stack',
+            stack: {
+              services: ['backend', 'front', 'admin'],
+            },
+          },
+          suites: {
+            help: { nodeType: 'category-node' },
+            description: 'Target grouping only',
+            full: {
+              command: 'echo grouped target',
+              description: 'Grouped target',
+            },
+          },
+          stagewise: {
+            command: 'echo stagewise bridge',
+            description: 'Stagewise bridge',
+          },
+        },
+      },
+      'start',
+      {
+        registeredCommands: ['start'],
+      },
+    )
+
+    expect(model.targets.map(target => target.name)).toEqual(['stack', 'stagewise'])
+  })
+
+  test('help model hides orchestration nodes by default unless help.expose=true', async () => {
+    const { getCommandHelpModel } = await loadHelpModel()
+
+    const model = getCommandHelpModel(
+      {
+        build: {
+          shared: {
+            command: 'echo build shared',
+            description: 'Build shared package',
+          },
+          parallelWeb: {
+            concurrent: true,
+            commands: ['build.shared'],
+            description: 'Parallel web build bridge',
+          },
+          releaseTrain: {
+            help: { expose: true },
+            sequential: true,
+            commands: ['build.shared'],
+            description: 'Visible release train',
+          },
+        },
+      },
+      'build',
+      {
+        registeredCommands: ['build'],
+      },
+    )
+
+    expect(model.targets.map(target => target.name)).toEqual(['shared', 'releaseTrain'])
+    expect(model.targets.find(target => target.name === 'releaseTrain')?.nodeType).toBe(
+      'orchestration-node',
+    )
+  })
+
+  test('summary prefers help.summary and falls back to description', async () => {
+    const { getCommandHelpModel } = await loadHelpModel()
+
+    const summaryFromHelp = getCommandHelpModel(
+      {
+        start: {
+          help: { summary: '启动/桥接服务' },
+          description: '旧摘要',
+        },
+      },
+      'start',
+      { registeredCommands: ['start'] },
+    )
+
+    const summaryFromDescription = getCommandHelpModel(
+      {
+        deploy: {
+          description: '构建并部署 backend 制品到远端主机',
+        },
+      },
+      'deploy',
+      { registeredCommands: ['deploy'] },
+    )
+
+    expect(summaryFromHelp.summary).toBe('启动/桥接服务')
+    expect(summaryFromDescription.summary).toBe('构建并部署 backend 制品到远端主机')
+  })
+
+  test('usage fallback is command-aware when help.usage is absent', async () => {
+    const { getCommandHelpModel } = await loadHelpModel()
+
+    const startModel = getCommandHelpModel(
+      {
+        start: {
+          backend: {
+            development: {
+              command: 'echo start backend',
+            },
+          },
+          stack: {
+            internal: 'pm2-stack',
+          },
+        },
+      },
+      'start',
+      { registeredCommands: ['start'] },
+    )
+
+    const buildModel = getCommandHelpModel(
+      {
+        build: {
+          backend: {
+            development: {
+              command: 'echo build backend',
+            },
+          },
+          shared: {
+            command: 'echo build shared',
+          },
+        },
+      },
+      'build',
+      { registeredCommands: ['build'] },
+    )
+
+    expect(startModel.usage).toBe('dx start <service> [环境标志]')
+    expect(buildModel.usage).toBe('dx build <target> [环境标志]')
+  })
+})
+
+describe('dynamic help renderer', () => {
+  test('command help renders target metadata and hides orchestration nodes by default', async () => {
+    const { renderCommandHelp } = await loadHelpRenderer()
+
+    const output = renderCommandHelp({
+      name: 'deploy',
+      usage: 'dx deploy <target> [环境标志]',
+      summary: '部署前端到 Vercel 或后端制品到远端主机',
+      notes: ['backend 制品发布目标默认 --dev'],
+      examples: [
+        {
+          command: 'dx deploy backend --prod',
+          description: '构建 backend 制品并部署到远端主机',
+        },
+      ],
+      targets: [
+        {
+          name: 'backend',
+          nodeType: 'target-leaf',
+          summary: '构建并部署 backend 制品到远端主机',
+          notes: ['支持跳过远端迁移'],
+          options: [
+            {
+              flags: ['--build-only'],
+              description: '仅构建制品，不执行远端部署',
+            },
+            {
+              flags: ['--skip-migration'],
+              description: '远端部署时跳过 prisma migrate deploy',
+            },
+          ],
+          examples: [
+            {
+              command: 'dx deploy backend --build-only',
+              description: '仅构建 backend 制品',
+            },
+          ],
+        },
+        {
+          name: 'parallel-web',
+          nodeType: 'orchestration-node',
+          summary: '内部编排节点',
+        },
+      ],
+    })
+
+    expect(output).toContain('部署前端到 Vercel 或后端制品到远端主机')
+    expect(output).toContain('构建并部署 backend 制品到远端主机')
+    expect(output).toContain('--build-only')
+    expect(output).toContain('--skip-migration')
+    expect(output).toContain('dx deploy backend --build-only')
+    expect(output).not.toContain('parallel-web')
+  })
+
+  test('global help wrapper falls back to generic dynamic output without explicit cli context', async () => {
+    const { showHelp } = await loadHelpRuntime()
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      showHelp()
+
+      const output = logSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('DX CLI v')
+      expect(output).toContain('用法:')
+      expect(output).not.toContain('统一开发环境管理工具')
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  test('global help stays dynamic when command summaries are missing', async () => {
+    const { showHelp } = await loadHelpRuntime()
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const cli = {
+      invocation: 'dx',
+      commands: {
+        start: {},
+        deploy: {},
+      },
+      commandHandlers: {
+        start: () => {},
+        deploy: () => {},
+      },
+      flagDefinitions: {
+        _global: [],
+      },
+    }
+
+    try {
+      showHelp(cli)
+
+      const output = logSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('DX CLI v')
+      expect(output).toContain('用法:')
+      expect(output).toContain('命令:')
+      expect(output).toContain('  start')
+      expect(output).toContain('  deploy')
+      expect(output).not.toContain('统一开发环境管理工具')
+      expect(output).not.toContain('initial')
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  test('command help stays dynamic when migrated help metadata is missing', async () => {
+    const { showCommandHelp } = await loadHelpRuntime()
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const cli = {
+      invocation: 'dx',
+      commands: {
+        start: {
+          backend: {
+            development: {
+              command: 'echo start backend',
+            },
+          },
+          stack: {
+            internal: 'pm2-stack',
+          },
+        },
+      },
+      commandHandlers: {
+        start: () => {},
+      },
+      flagDefinitions: {
+        _global: [],
+      },
+    }
+
+    try {
+      showCommandHelp('start', cli)
+
+      const output = logSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('start 命令用法:')
+      expect(output).toContain('dx start <service> [环境标志]')
+      expect(output).toContain('可用 target:')
+      expect(output).toContain('backend')
+      expect(output).toContain('stack')
+      expect(output).not.toContain('服务说明:')
+      expect(output).not.toContain('stagewise-front')
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  test('handleHelp uses live cli context for global help output', async () => {
+    const { handleHelp } = await loadCoreCommands()
+    const configDir = createTempConfig({
+      help: {
+        summary: 'Scoped DX help',
+        commands: {
+          start: { summary: 'Start summary' },
+        },
+      },
+      start: {},
+      ghost: {},
+    })
+    tempPaths.add(configDir)
+    process.env.DX_CONFIG_DIR = configDir
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const cli = {
+      invocation: 'dx',
+      commands: {
+        help: {
+          summary: 'Scoped DX help',
+          commands: {
+            start: { summary: 'Start summary' },
+          },
+        },
+        start: {},
+        ghost: {},
+      },
+      commandHandlers: {
+        start: () => {},
+      },
+      flagDefinitions: {
+        _global: [],
+      },
+    }
+
+    try {
+      handleHelp(cli, [])
+
+      const output = logSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('Scoped DX help')
+      expect(output).toContain('Start summary')
+      expect(output).not.toContain('Ghost summary')
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  test('help positional validation still rejects dx help <command> <target>', async () => {
+    const { DxCli } = await loadDxCli()
+    const argvBackup = process.argv
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {
+      throw new Error(`process.exit:${code}`)
+    })
+    const configDir = resolve(process.cwd(), 'example', 'dx', 'config')
+
+    try {
+      process.argv = ['node', 'dx', 'help', 'start', 'stack']
+      const cli = new DxCli({ configDir })
+
+      expect(() => cli.validateInputs()).toThrow('process.exit:1')
+    } finally {
+      process.argv = argvBackup
+      exitSpy.mockRestore()
+    }
+  })
+})

--- a/test/dynamic-help-schema.test.js
+++ b/test/dynamic-help-schema.test.js
@@ -1,0 +1,217 @@
+import { describe, expect, test } from '@jest/globals'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { DxCli } from '../lib/cli/dx-cli.js'
+
+async function loadValidateHelpConfig() {
+  const module = await import('../lib/cli/help-schema.js')
+  return module.validateHelpConfig
+}
+
+function getRuntimeHelpContext() {
+  const argvBackup = process.argv
+
+  try {
+    process.argv = ['node', 'dx']
+
+    const cli = new DxCli({
+      configDir: join(process.cwd(), 'example', 'dx', 'config'),
+    })
+
+    const knownFlags = new Map()
+
+    for (const definitions of Object.values(cli.flagDefinitions)) {
+      for (const definition of definitions) {
+        knownFlags.set(definition.flag, definition)
+      }
+    }
+
+    return {
+      knownFlags,
+      registeredCommands: Object.keys(cli.commandHandlers),
+    }
+  } finally {
+    process.argv = argvBackup
+  }
+}
+
+describe('dynamic help schema', () => {
+  test('rejects unknown help option flags', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          help: {
+            globalOptions: [{ flags: ['--unknown'], description: 'bad' }],
+          },
+        },
+        getRuntimeHelpContext(),
+      ),
+    ).toThrow('--unknown')
+  })
+
+  test('rejects help examples that reference unknown commands', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          help: {
+            commands: {
+              start: {
+                summary: 'Start services',
+                examples: [{ command: 'dx nope x', description: 'bad' }],
+              },
+            },
+          },
+        },
+        getRuntimeHelpContext(),
+      ),
+    ).toThrow('nope')
+  })
+
+  test('passes current config with runtime-derived registries', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+    const file = join(process.cwd(), 'dx', 'config', 'commands.json')
+    const commands = JSON.parse(readFileSync(file, 'utf8'))
+
+    expect(() => validateHelpConfig(commands, getRuntimeHelpContext())).not.toThrow()
+  })
+
+  test('rejects invalid command usage through usage validator callback', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          help: {
+            commands: {
+              start: {
+                summary: 'Start services',
+                usage: 'dx start <bad>',
+              },
+            },
+          },
+        },
+        {
+          ...getRuntimeHelpContext(),
+          usageValidator: (commandName, usage) =>
+            commandName === 'start' && usage === 'dx start <bad>'
+              ? { ok: false, reason: 'invalid usage for start' }
+              : { ok: true },
+        },
+      ),
+    ).toThrow('invalid usage for start')
+  })
+
+  test('rejects invalid examples through example validator callback', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          help: {
+            commands: {
+              start: {
+                summary: 'Start services',
+                examples: [{ command: 'dx start backend --dev', description: 'bad example' }],
+              },
+            },
+          },
+        },
+        {
+          ...getRuntimeHelpContext(),
+          exampleValidator: command =>
+            command === 'dx start backend --dev'
+              ? { ok: false, reason: 'example rejected by parser' }
+              : { ok: true },
+        },
+      ),
+    ).toThrow('example rejected by parser')
+  })
+
+  test('accepts target help mounted at help.targets.<command>.<target>', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          start: {
+            backend: {
+              dev: {
+                command: 'echo backend',
+                description: 'Start backend',
+              },
+            },
+          },
+          help: {
+            targets: {
+              start: {
+                backend: {
+                  summary: 'Start backend target',
+                  options: [{ flags: ['--dev'], description: 'Use development environment' }],
+                  examples: [
+                    {
+                      command: 'dx start backend --dev',
+                      description: 'Start backend in dev mode',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        getRuntimeHelpContext(),
+      ),
+    ).not.toThrow()
+  })
+
+  test('rejects target help safe mount for unknown commands', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          help: {
+            targets: {
+              nope: {
+                backend: {
+                  summary: 'bad mount',
+                },
+              },
+            },
+          },
+        },
+        getRuntimeHelpContext(),
+      ),
+    ).toThrow('help.targets.nope references unknown command')
+  })
+
+  test('rejects target help safe mount for unknown targets', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          deploy: {
+            front: {
+              description: 'Deploy front',
+            },
+          },
+          help: {
+            targets: {
+              deploy: {
+                backend: {
+                  summary: 'bad mount',
+                },
+              },
+            },
+          },
+        },
+        getRuntimeHelpContext(),
+      ),
+    ).toThrow('help.targets.deploy.backend references unknown target')
+  })
+})

--- a/test/start-command-guard.test.js
+++ b/test/start-command-guard.test.js
@@ -32,7 +32,7 @@ describe('dx start command guard', () => {
 
     expect(result.code).not.toBe(0)
     expect(result.output).toContain('dx start 在未指定服务时仅允许使用开发环境')
-    expect(result.output).toContain('dx start all --dev')
+    expect(result.output).toContain('dx start --dev')
     expect(result.output).toContain('dx start backend --prod')
   })
 

--- a/test/start-stack-config.test.js
+++ b/test/start-stack-config.test.js
@@ -1,7 +1,27 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
+
+const logger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  step: jest.fn(),
+}
+
+jest.unstable_mockModule('../lib/logger.js', () => ({
+  logger,
+}))
+
+const { handleStart } = await import('../lib/cli/commands/start.js')
+const { DxCli } = await import('../lib/cli/dx-cli.js')
+const { FLAG_DEFINITIONS } = await import('../lib/cli/flags.js')
+const { showCommandHelp } = await import('../lib/cli/help.js')
 
 describe('start stack configuration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   test('handleStart no longer hard-codes stack branch', () => {
     const file = join(process.cwd(), 'lib', 'cli', 'commands', 'start.js')
     const source = readFileSync(file, 'utf8')
@@ -18,4 +38,52 @@ describe('start stack configuration', () => {
     expect(commands.start.stack.internal).toBe('pm2-stack')
     expect(Array.isArray(commands.start.stack?.stack?.services)).toBe(true)
   })
+
+  test('DxCli positional validation rejects stack subcommands as extra parameters', () => {
+    const argvBackup = process.argv
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {
+      throw new Error(`process.exit:${code}`)
+    })
+
+    try {
+      process.argv = ['node', 'dx', 'start', 'stack', 'front']
+      const cli = new DxCli({
+        configDir: resolve(process.cwd(), 'example', 'dx', 'config'),
+      })
+
+      expect(() => cli.validatePositionalArgs('start', ['stack', 'front'])).toThrow('process.exit:1')
+      expect(logger.error).toHaveBeenCalledWith('命令 start 存在未识别的额外参数: front')
+    } finally {
+      process.argv = argvBackup
+      exitSpy.mockRestore()
+    }
+  })
+
+  test('dynamic start help includes stack notes from config help metadata', async () => {
+    const file = join(process.cwd(), 'dx', 'config', 'commands.json')
+    const commands = JSON.parse(readFileSync(file, 'utf8'))
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const cli = {
+      invocation: 'dx',
+      commands,
+      commandHandlers: {
+        start: () => {},
+      },
+      flagDefinitions: FLAG_DEFINITIONS,
+    }
+
+    try {
+      showCommandHelp('start', cli)
+
+      const output = logSpy.mock.calls.flat().join('\n')
+      expect(output).toContain('启动/桥接服务')
+      expect(output).toContain('dx start <service> [环境标志]')
+      expect(output).toContain('未指定 service 时默认使用开发套件，仅允许 --dev')
+      expect(output).toContain('dx start backend --dev')
+      expect(output).toContain('dx start stack')
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
 })

--- a/test/test-command-e2e-guard.test.js
+++ b/test/test-command-e2e-guard.test.js
@@ -74,15 +74,11 @@ describe('dx test e2e backend guard', () => {
   })
 
   test('help output only shows path-based backend e2e examples', () => {
-    const result = runDx(['--help'])
+    const result = runDx(['help', 'test'])
 
     expect(result.code).toBe(0)
-    expect(result.output).not.toContain('target: backend, all (默认: all)')
-    expect(result.output).toContain('path: 测试文件或目录路径 (guarded e2e target 必填，例如 backend/quantify)')
-    expect(result.output).toContain('dx test e2e backend apps/backend/e2e/auth')
-    expect(result.output).toContain('dx test e2e quantify apps/quantify/e2e/health/health.e2e-spec.ts')
-    expect(result.output).toContain('dx test e2e all          # 不受支持，必须指定 target 和 path')
-    expect(result.output).not.toContain('dx test e2e backend                           # 运行后端E2E测试')
+    expect(result.output).toContain('test 命令用法:')
+    expect(result.output).toContain('dx test [type] <target> [path]')
   })
 })
 


### PR DESCRIPTION
变更说明：
- 移除旧的 CLI 与配置兼容层，统一只认 strict 新规范的环境键、命令入口和帮助输出
- 将 help 切换为配置驱动的 schema/model/renderer 流程，并在运行时增加严格校验
- 重写 demo/example 文档与配置示例，同时迁移 ai-monorepo 的 dx 配置到最新规范

Refs: #32