### PR TITLE
fix: support multiple unit test paths

### DIFF
--- a/lib/cli/commands/core.js
+++ b/lib/cli/commands/core.js
@@ -71,7 +71,8 @@ export async function handleBuild(cli, args) {
 export async function handleTest(cli, args) {
   const type = args[0] || 'e2e'
   const target = args[1] || 'all'
-  const testPath = args[2] // 可选的测试文件路径
+  const testPaths = args.slice(2) // unit 可选多个测试文件路径；e2e 只使用第一个
+  const testPath = testPaths[0]
 
   // 解析 -t 参数用于指定特定测试用例（使用原始参数列表）
   const allArgs = cli.args  // 使用原始参数列表包含所有标志
@@ -137,15 +138,17 @@ export async function handleTest(cli, args) {
     } else {
       logger.step(`运行单个 ${type} 测试: ${testPath}`)
     }
-  } else if (type === 'unit' && testPath) {
+  } else if (type === 'unit' && testPaths.length > 0) {
     let command = String(testConfig.command).trim()
     const useDirectPathArg = shouldUseDirectPathArg(command)
-    const normalizedTestPath = useDirectPathArg
-      ? normalizeUnitTestPathForCommand(cli, command, testPath)
-      : testPath
+    const normalizedTestPaths = testPaths.map(path =>
+      useDirectPathArg
+        ? normalizeUnitTestPathForCommand(cli, command, path)
+        : path
+    )
     const forwardedArgs = useDirectPathArg
-      ? [shellEscape(normalizedTestPath)]
-      : [`--runTestsByPath ${shellEscape(normalizedTestPath)}`]
+      ? normalizedTestPaths.map(shellEscape)
+      : [`--runTestsByPath ${normalizedTestPaths.map(shellEscape).join(' ')}`]
 
     if (testNamePattern) {
       forwardedArgs.push(`-t ${shellEscape(testNamePattern)}`)
@@ -161,14 +164,14 @@ export async function handleTest(cli, args) {
       ...testConfig,
       command,
       description: testNamePattern
-        ? `运行单个单元测试文件的特定用例: ${testPath} -> ${testNamePattern}`
-        : `运行单个单元测试文件: ${testPath}`,
+        ? `运行单元测试文件的特定用例: ${testPaths.join(', ')} -> ${testNamePattern}`
+        : `运行单元测试文件: ${testPaths.join(', ')}`,
     }
 
     if (testNamePattern) {
-      logger.step(`运行 ${type} 测试用例: ${testNamePattern} (文件: ${testPath})`)
+      logger.step(`运行 ${type} 测试用例: ${testNamePattern} (文件: ${testPaths.join(', ')})`)
     } else {
-      logger.step(`运行单个 ${type} 测试: ${testPath}`)
+      logger.step(`运行 ${type} 测试: ${testPaths.join(', ')}`)
     }
   } else {
     logger.step(`运行 ${type} 测试`)

--- a/lib/cli/dx-cli.js
+++ b/lib/cli/dx-cli.js
@@ -560,7 +560,9 @@ class DxCli {
       }
       case 'test':
         this.validateTestPositionals(positionalArgs)
-        ensureMax(3)
+        if ((positionalArgs[0] || 'e2e') !== 'unit') {
+          ensureMax(3)
+        }
         break
       case 'worktree': {
         if (positionalArgs.length === 0) return

--- a/lib/cli/help-schema.js
+++ b/lib/cli/help-schema.js
@@ -333,8 +333,6 @@ function getRuntimeMaxPositionals(commandName) {
       return 1
     case 'db':
       return 2
-    case 'test':
-      return 3
     case 'worktree':
       return 3
     case 'start':
@@ -442,7 +440,6 @@ function validateArgumentTokens(args, cli) {
     build: 1,
     package: 1,
     db: 2,
-    test: 3,
     worktree: 3,
     start: 1,
     lint: 0,

--- a/lib/cli/help-schema.js
+++ b/lib/cli/help-schema.js
@@ -293,18 +293,18 @@ export function validateUsageAgainstRuntime(commandName, usageText, cli) {
     }
   }
 
-  const placeholderTokens = tokens
+  const runtimePositionals = tokens
     .slice(2)
-    .filter(token => isPlaceholderToken(token) && !isEnvironmentPlaceholder(token))
-  const runtimeMaxPositionals = getRuntimeMaxPositionals(commandName)
+    .filter(token => !isEnvironmentPlaceholder(token))
+  const runtimeMaxPositionals = getRuntimeMaxPositionals(commandName, tokens)
 
   if (
     Number.isInteger(runtimeMaxPositionals) &&
-    placeholderTokens.length > runtimeMaxPositionals
+    runtimePositionals.length > runtimeMaxPositionals
   ) {
     return {
       ok: false,
-      reason: `usage for ${commandName} advertises ${placeholderTokens.length} positionals but runtime allows ${runtimeMaxPositionals}`,
+      reason: `usage for ${commandName} advertises ${runtimePositionals.length} positionals but runtime allows ${runtimeMaxPositionals}`,
     }
   }
 
@@ -322,7 +322,7 @@ export function validateUsageAgainstRuntime(commandName, usageText, cli) {
   return { ok: true }
 }
 
-function getRuntimeMaxPositionals(commandName) {
+function getRuntimeMaxPositionals(commandName, tokens = []) {
   switch (commandName) {
     case 'help':
       return 1
@@ -335,6 +335,8 @@ function getRuntimeMaxPositionals(commandName) {
       return 2
     case 'worktree':
       return 3
+    case 'test':
+      return tokens[2] === 'unit' ? null : 3
     case 'start':
       return 1
     case 'lint':
@@ -448,7 +450,11 @@ function validateArgumentTokens(args, cli) {
     status: 0,
   }
 
-  const max = maxByCommand[commandName]
+  let max = maxByCommand[commandName]
+  if (commandName === 'test') {
+    max = positionalArgs[0] === 'unit' ? null : 3
+  }
+
   if (Number.isInteger(max) && positionalArgs.length > max) {
     return { ok: false, reason: `命令 ${commandName} 存在未识别的额外参数: ${positionalArgs.slice(max).join(', ')}` }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@ranger1/dx':
-        specifier: 0.1.67
-        version: 0.1.67
       strip-json-comments:
         specifier: ^5.0.3
         version: 5.0.3
@@ -367,11 +364,6 @@ packages:
     resolution: {integrity: sha512-Jb8YsA7/GKGWWg2RkaDJQalaOpiQCPb57PtxNV5Ai7bsapM/7g/OfwenZXfH32FUoCT4yPVrnrKdjqbBHdEkxA==}
     cpu: [x64]
     os: [win32]
-
-  '@ranger1/dx@0.1.67':
-    resolution: {integrity: sha512-d1S+xneCtpf0X5l4YILUf0iObACdHTFnOCMUFaPWb1IEEDTIHVf2hBx6nPGrZtI0yPSq6pgwKHFGzWlyYl/U6A==}
-    engines: {node: '>=20.11.0'}
-    hasBin: true
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1937,11 +1929,6 @@ snapshots:
 
   '@nx/nx-win32-x64-msvc@22.4.4':
     optional: true
-
-  '@ranger1/dx@0.1.67':
-    dependencies:
-      strip-json-comments: 5.0.3
-      yaml: 2.8.2
 
   '@sinclair/typebox@0.27.8': {}
 

--- a/test/compatibility-purge-batch3.test.js
+++ b/test/compatibility-purge-batch3.test.js
@@ -56,6 +56,9 @@ function createCli({ flags = {}, args = [], getWorktreeManager } = {}) {
 describe('compatibility purge batch 3', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    worktreeManager.repoRoot = '/tmp/dx'
+    worktreeManager.baseDir = '/tmp'
+    worktreeManager.prefix = 'dx_issue_'
     fsMock.existsSync.mockImplementation(() => false)
     delete process.exitCode
   })

--- a/test/dynamic-help-schema.test.js
+++ b/test/dynamic-help-schema.test.js
@@ -9,30 +9,38 @@ async function loadValidateHelpConfig() {
   return module.validateHelpConfig
 }
 
-function getRuntimeHelpContext() {
+async function loadStrictHelpValidationContext() {
+  const module = await import('../lib/cli/help-schema.js')
+  return module.buildStrictHelpValidationContext
+}
+
+function createRuntimeCli() {
   const argvBackup = process.argv
 
   try {
     process.argv = ['node', 'dx']
 
-    const cli = new DxCli({
+    return new DxCli({
       configDir: join(process.cwd(), 'example', 'dx', 'config'),
     })
-
-    const knownFlags = new Map()
-
-    for (const definitions of Object.values(cli.flagDefinitions)) {
-      for (const definition of definitions) {
-        knownFlags.set(definition.flag, definition)
-      }
-    }
-
-    return {
-      knownFlags,
-      registeredCommands: Object.keys(cli.commandHandlers),
-    }
   } finally {
     process.argv = argvBackup
+  }
+}
+
+function getRuntimeHelpContext() {
+  const cli = createRuntimeCli()
+  const knownFlags = new Map()
+
+  for (const definitions of Object.values(cli.flagDefinitions)) {
+    for (const definition of definitions) {
+      knownFlags.set(definition.flag, definition)
+    }
+  }
+
+  return {
+    knownFlags,
+    registeredCommands: Object.keys(cli.commandHandlers),
   }
 }
 
@@ -78,6 +86,28 @@ describe('dynamic help schema', () => {
     const commands = JSON.parse(readFileSync(file, 'utf8'))
 
     expect(() => validateHelpConfig(commands, getRuntimeHelpContext())).not.toThrow()
+  })
+
+  test('rejects e2e test usage with more than one path placeholder', async () => {
+    const validateHelpConfig = await loadValidateHelpConfig()
+    const buildStrictHelpValidationContext = await loadStrictHelpValidationContext()
+    const cli = createRuntimeCli()
+
+    expect(() =>
+      validateHelpConfig(
+        {
+          help: {
+            commands: {
+              test: {
+                summary: 'Run tests',
+                usage: 'dx test e2e backend <path> <extra>',
+              },
+            },
+          },
+        },
+        buildStrictHelpValidationContext(cli),
+      ),
+    ).toThrow('runtime allows 3')
   })
 
   test('rejects invalid command usage through usage validator callback', async () => {

--- a/test/test-command-unit-path.test.js
+++ b/test/test-command-unit-path.test.js
@@ -107,6 +107,24 @@ describe('dx test unit path forwarding', () => {
     expect(result.output).toContain(testPath)
   })
 
+  test('unit target with multiple paths appends every path to --runTestsByPath', () => {
+    const configDir = createTempConfigDir(createCommandsFixture())
+    const workspaceDir = createRunnableWorkspace()
+    const firstPath = 'apps/backend/src/modules/chat/chat.service.spec.ts'
+    const secondPath = 'apps/backend/src/modules/user/user.service.spec.ts'
+
+    const result = runDx(
+      ['--config-dir', configDir, 'test', 'unit', 'backend', firstPath, secondPath],
+      { cwd: workspaceDir },
+    )
+
+    expect(result.code).toBe(0)
+    expect(result.output).toContain('backend:test')
+    expect(result.output).toContain('--runTestsByPath')
+    expect(result.output).toContain(firstPath)
+    expect(result.output).toContain(secondPath)
+  })
+
   test('unit target with path and -t appends both filters', () => {
     const configDir = createTempConfigDir(createCommandsFixture())
     const workspaceDir = createRunnableWorkspace()
@@ -208,6 +226,33 @@ describe('dx test unit path forwarding', () => {
 
     expect(result.code).toBe(0)
     expect(result.output).toContain(`nx test front 'src/lib/url-param-persistence.test.ts'`)
+  })
+
+  test('nx vitest target rewrites and forwards multiple workspace paths', () => {
+    const configDir = createTempConfigDir(createCommandsFixture())
+    const workspaceDir = createRunnableWorkspace()
+    writeProjectConfig(workspaceDir, 'front', {
+      targets: {
+        test: {
+          options: {
+            command: 'vitest run',
+            cwd: 'apps/front',
+          },
+        },
+      },
+    })
+    const firstPath = 'apps/front/src/lib/i18n/config.spec.ts'
+    const secondPath = 'apps/front/src/components/provider/I18nProvider.spec.tsx'
+
+    const result = runDx(
+      ['--config-dir', configDir, 'test', 'unit', 'front', firstPath, secondPath],
+      { cwd: workspaceDir },
+    )
+
+    expect(result.code).toBe(0)
+    expect(result.output).toContain(
+      `nx test front 'src/lib/i18n/config.spec.ts' 'src/components/provider/I18nProvider.spec.tsx'`,
+    )
   })
 
   test('nx jest target rewrites workspace path to project-root relative path', () => {


### PR DESCRIPTION
## 变更目的

- 对应 `shitgood-bradford54/ai-monorepo#6424`：让 `dx test unit <target>` 支持多个测试文件/目录路径，并正确透传给 Nx/Vitest。
- 保持后端 E2E 无路径 guard 不变，避免恢复无参全量 E2E。
- 补充 CLI 参数解析和 unit 多路径透传自动化测试。

## 主要改动和解决的问题

- `lib/cli/dx-cli.js`：仅对非 unit 测试继续限制 test 命令最多 3 个 positional；unit 允许多个路径。
- `lib/cli/commands/core.js`：unit 测试收集 `args.slice(2)` 并逐个归一化/转发；Vitest/Nx direct path 模式支持多个路径。
- `lib/cli/help-schema.js`：移除静态 test positional 上限，避免 help schema 先于 runtime 拒绝 unit 多路径。
- `test/test-command-unit-path.test.js`：新增 `--runTestsByPath` 多路径和 Nx/Vitest 多路径转发覆盖。
- `test/compatibility-purge-batch3.test.js`：固定测试夹具的仓库前缀，避免测试依赖临时 clone 目录名。

## 遗留的问题

- 无。

## 已做的验证

- `pnpm install --frozen-lockfile`：通过。
- `npm test -- test/compatibility-purge-batch3.test.js`：通过，5/5。
- `npm test -- test/test-command-unit-path.test.js`：通过，9/9。
- `npm test -- test/test-command-e2e-guard.test.js`：通过，10/10。
- `npm test -- test/dynamic-help-schema.test.js`：通过，8/8。
- `node --check lib/cli/dx-cli.js`：通过。
- `node --check lib/cli/commands/core.js`：通过。
- `node --check lib/cli/help-schema.js`：通过。
- `npm test`：通过，41/41 suites，341/341 tests。

## PR 遗留未做的

- 无。

## 关联

Closes: shitgood-bradford54/ai-monorepo#6424
Refs: shitgood-bradford54/ai-monorepo#6425
